### PR TITLE
fix runtime inference feature pipeline drift

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 [run]
 # Required paths  - can also set with CLI args:
-video_path = "output_videos/Set_1_Play_Uncut_Derek_vs._Alex_short_segmented.mp4"
+# video_path = "raw_videos/your_match.mp4"
 output_dir = "output_videos"
 
 # Optional custom output base name - otherwise just "[video_name]_segmented.mp4"
@@ -12,22 +12,23 @@ segment_video = true
 csv_output_dir = "output_csvs" # defaults to input video directory
 
 # YOLO pose model choice: nano | small | medium | large
-yolo_model = "nano"
+yolo_model = "small"
 # Optional device: cpu | cuda | mps (defaults to auto; set to "mps" for Apple Silicon)
-yolo_device = "mps" # get mps warning so switches to cpu if don't set this var
+# yolo_device = "mps"
 
 # Optional overrides for assets:
 # model_path = "/path/to/lstm_300_v0.1.pth"
 # scaler_path = "/path/to/scaler_300_v0.1.joblib"
 
-# Pipeline parameters — defaults shown
-fps = 15.0
-seq_len = 300
-overlap = 150
-sigma = 1.5
+# Pipeline parameters — v0.3.1 model defaults shown
+fps = 5.0
+seq_len = 100
+overlap = 50
+sigma = 1.0
 low = 0.45
-high = 0.8
-min_dur_sec = 0.5
+high = 0.7
+min_dur_sec = 1.0
 conf = 0.25
+imgsz = 960
 start_time = 0
 duration = 999999

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -59,6 +59,7 @@ class RunConfig:
     high: float = 0.8
     min_dur_sec: float = 0.5
     conf: float = 0.25
+    imgsz: int = 1920
     start_time: int = 0
     duration: int = 999999
 
@@ -128,10 +129,10 @@ def _pick_bool(arg_val: Optional[bool], cfg_val: Optional[Any], default: bool) -
     return default
 
 
-def _manifest_defaults_for_model(model_path: Path) -> Dict[str, Any]:
-    if model_path.suffix.lower() != ".onnx":
+def _manifest_defaults_for_model(model_path: Path, manifest_path: Optional[Path] = None) -> Dict[str, Any]:
+    if manifest_path is None and model_path.suffix.lower() != ".onnx":
         return {}
-    manifest_path = model_path.parent / "manifest.json"
+    manifest_path = manifest_path or (model_path.parent / "manifest.json")
     if not manifest_path.exists():
         return {}
     try:
@@ -148,6 +149,8 @@ def _manifest_defaults_for_model(model_path: Path) -> Dict[str, Any]:
         defaults["overlap"] = int(inference["overlap_frames"])
     if "target_fps" in feature_pipeline:
         defaults["fps"] = float(feature_pipeline["target_fps"])
+    if "imgsz" in feature_pipeline:
+        defaults["imgsz"] = int(float(feature_pipeline["imgsz"]))
     if "sigma" in postprocess:
         defaults["sigma"] = float(postprocess["sigma"])
     if "low" in postprocess:
@@ -160,35 +163,48 @@ def _manifest_defaults_for_model(model_path: Path) -> Dict[str, Any]:
 
 
 def build_run_config(args: argparse.Namespace) -> RunConfig:
-    cfg_path = args.config or ("config.toml" if Path("config.toml").exists() else None)
-    cfg_dict = _load_config_dict(cfg_path) if (cfg_path and Path(cfg_path).exists()) else {}
+    def arg(key: str, default=None):
+        return getattr(args, key, default)
+
+    cfg_path = arg("config") or (None if arg("video") else ("config.toml" if Path("config.toml").exists() else None))
+    cfg_dict = _load_config_dict(cfg_path) if cfg_path else {}
     cfg_section = cfg_dict.get("run", cfg_dict) if isinstance(cfg_dict, dict) else {}
 
     def cfg(key: str, default=None):
         return cfg_section.get(key, default) if isinstance(cfg_section, dict) else default
 
-    video_path = args.video or cfg("video_path")
-    output_dir = args.output_dir or cfg("output_dir") or str(Path.cwd() / "output_videos")
+    video_path = arg("video") or cfg("video_path")
+    output_dir = arg("output_dir") or cfg("output_dir") or str(Path.cwd() / "output_videos")
     if not video_path:
         raise SystemExit("Please provide a video via CLI flag or config [run] section.")
 
-    output_name = args.output_name or cfg("output_name")
-    csv_output_dir_raw = args.csv_output_dir or cfg("csv_output_dir")
+    output_name = arg("output_name") or cfg("output_name")
+    csv_output_dir_raw = arg("csv_output_dir") or cfg("csv_output_dir")
 
-    yolo_choice = args.yolo_size or cfg("yolo_model")
+    yolo_choice = arg("yolo_size") or cfg("yolo_model")
     if yolo_choice and yolo_choice in YOLO_SIZE_MAP:
         yolo_weights = YOLO_SIZE_MAP[yolo_choice]
     elif yolo_choice:
         yolo_weights = str(yolo_choice)
     else:
         yolo_weights = YOLO_SIZE_MAP["small"]
-    yolo_device = args.yolo_device or cfg("yolo_device")
+    yolo_device = arg("yolo_device") or cfg("yolo_device")
 
-    write_csv = _pick_bool(args.write_csv, cfg("write_csv"), False)
-    segment_video_flag = _pick_bool(args.segment_video, cfg("segment_video"), True)
+    write_csv = _pick_bool(arg("write_csv"), cfg("write_csv"), False)
+    segment_video_flag = _pick_bool(arg("segment_video"), cfg("segment_video"), True)
+
+    artifact_dir_raw = arg("artifact_dir") or cfg("artifact_dir")
+    artifact_dir = Path(artifact_dir_raw).expanduser().resolve() if artifact_dir_raw else None
+    model_path_raw = arg("model_path") or cfg("model_path")
+    scaler_path_raw = arg("scaler_path") or cfg("scaler_path")
+    manifest_path_raw = arg("manifest_path") or cfg("manifest_path")
+    if artifact_dir is not None:
+        model_path_raw = model_path_raw or str(artifact_dir / "model.onnx")
+        scaler_path_raw = scaler_path_raw or str(artifact_dir / "scaler.json")
+        manifest_path_raw = manifest_path_raw or str(artifact_dir / "manifest.json")
 
     model_path = _resolve_asset(
-        args.model_path or cfg("model_path"),
+        model_path_raw,
         env_var="RALLYCLIP_MODEL_PATH",
         relatives=[
             "models/rallyclip_v0.3.1/model.onnx",
@@ -198,7 +214,7 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
         description="RallyClip model artifact (ONNX or PyTorch checkpoint)",
     )
     scaler_path = _resolve_asset(
-        args.scaler_path or cfg("scaler_path"),
+        scaler_path_raw,
         env_var="RALLYCLIP_SCALER_PATH",
         relatives=[
             "models/rallyclip_v0.3.1/scaler.json",
@@ -207,7 +223,8 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
         ],
         description="RallyClip scaler artifact (JSON or joblib)",
     )
-    manifest_defaults = _manifest_defaults_for_model(model_path)
+    manifest_path = Path(manifest_path_raw).expanduser().resolve() if manifest_path_raw else None
+    manifest_defaults = _manifest_defaults_for_model(model_path, manifest_path)
 
     return RunConfig(
         video_path=Path(video_path).expanduser().resolve(),
@@ -220,16 +237,17 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
         yolo_device=yolo_device,
         model_path=model_path,
         scaler_path=scaler_path,
-        fps=float(args.fps if args.fps is not None else cfg("fps", manifest_defaults.get("fps", 15.0))),
-        seq_len=int(args.seq_len if args.seq_len is not None else cfg("seq_len", manifest_defaults.get("seq_len", 300))),
-        overlap=int(args.overlap if args.overlap is not None else cfg("overlap", manifest_defaults.get("overlap", 150))),
-        sigma=float(args.sigma if args.sigma is not None else cfg("sigma", manifest_defaults.get("sigma", 1.5))),
-        low=float(args.low if args.low is not None else cfg("low", manifest_defaults.get("low", 0.45))),
-        high=float(args.high if args.high is not None else cfg("high", manifest_defaults.get("high", 0.8))),
-        min_dur_sec=float(args.min_dur_sec if args.min_dur_sec is not None else cfg("min_dur_sec", manifest_defaults.get("min_dur_sec", 0.5))),
-        conf=float(args.conf if args.conf is not None else cfg("conf", 0.25)),
-        start_time=int(args.start_time if args.start_time is not None else cfg("start_time", 0)),
-        duration=int(args.duration if args.duration is not None else cfg("duration", 999999)),
+        fps=float(arg("fps") if arg("fps") is not None else cfg("fps", manifest_defaults.get("fps", 15.0))),
+        seq_len=int(arg("seq_len") if arg("seq_len") is not None else cfg("seq_len", manifest_defaults.get("seq_len", 300))),
+        overlap=int(arg("overlap") if arg("overlap") is not None else cfg("overlap", manifest_defaults.get("overlap", 150))),
+        sigma=float(arg("sigma") if arg("sigma") is not None else cfg("sigma", manifest_defaults.get("sigma", 1.5))),
+        low=float(arg("low") if arg("low") is not None else cfg("low", manifest_defaults.get("low", 0.45))),
+        high=float(arg("high") if arg("high") is not None else cfg("high", manifest_defaults.get("high", 0.8))),
+        min_dur_sec=float(arg("min_dur_sec") if arg("min_dur_sec") is not None else cfg("min_dur_sec", manifest_defaults.get("min_dur_sec", 0.5))),
+        conf=float(arg("conf") if arg("conf") is not None else cfg("conf", 0.25)),
+        imgsz=int(arg("imgsz") if arg("imgsz") is not None else cfg("imgsz", manifest_defaults.get("imgsz", 1920))),
+        start_time=int(arg("start_time") if arg("start_time") is not None else cfg("start_time", 0)),
+        duration=int(arg("duration") if arg("duration") is not None else cfg("duration", 999999)),
     )
 
 
@@ -251,6 +269,7 @@ def run_pipeline(cfg: RunConfig) -> int:
         start_time_seconds=int(cfg.start_time),
         duration_seconds=int(cfg.duration),
         target_fps=int(cfg.fps),
+        imgsz=int(cfg.imgsz),
         annotations_csv=None,
     )
 
@@ -262,11 +281,14 @@ def run_pipeline(cfg: RunConfig) -> int:
         pre = DataPreprocessor(save_court_masks=False)
         pre.preprocess_single_video(raw_npz, str(cfg.video_path), str(preprocessed_npz), overwrite=True)
 
-        fe = FeatureEngineer()
+        try:
+            fe = FeatureEngineer(target_fps=float(cfg.fps))
+        except TypeError:
+            fe = FeatureEngineer()
         fe.create_features_from_preprocessed(str(preprocessed_npz), str(features_npz), overwrite=True)
 
-        data = np.load(str(features_npz))
-        features = data["features"]
+        with np.load(str(features_npz)) as data:
+            features = data["features"].copy()
         scaler = load_scaler_asset(str(cfg.scaler_path))
         features = scaler.transform(features)
         if cfg.model_path.suffix.lower() == ".onnx":
@@ -327,6 +349,8 @@ def main() -> int:
     p.add_argument("--csv-output-dir", help="Optional directory for CSV output (defaults to video directory)")
     p.add_argument("--model-path", help="Path to model artifact (.onnx preferred, legacy .pth supported)")
     p.add_argument("--scaler-path", help="Path to scaler artifact (.json preferred, legacy .joblib supported)")
+    p.add_argument("--artifact-dir", help="Directory containing model.onnx, scaler.json, and manifest.json")
+    p.add_argument("--manifest-path", help="Path to model manifest.json for runtime defaults")
     p.add_argument("--yolo-size", choices=list(YOLO_SIZE_MAP.keys()), help="YOLO pose model size (auto-downloads if needed)")
     p.add_argument("--yolo-device", choices=["cpu", "cuda", "mps"], help="Force YOLO device (overrides POSE_DEVICE env)")
 
@@ -338,6 +362,7 @@ def main() -> int:
     p.add_argument("--high", type=float, help="Hysteresis high threshold")
     p.add_argument("--min-dur-sec", type=float, help="Minimum segment duration in seconds")
     p.add_argument("--conf", type=float, help="Pose model confidence threshold")
+    p.add_argument("--imgsz", type=int, help="YOLO inference image size")
     p.add_argument("--start-time", type=int, help="Start time offset (seconds)")
     p.add_argument("--duration", type=int, help="Max duration to process (seconds)")
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -59,7 +59,7 @@ class RunConfig:
     high: float = 0.8
     min_dur_sec: float = 0.5
     conf: float = 0.25
-    imgsz: int = 1920
+    imgsz: int = 960
     start_time: int = 0
     duration: int = 999999
 
@@ -245,7 +245,7 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
         high=float(arg("high") if arg("high") is not None else cfg("high", manifest_defaults.get("high", 0.8))),
         min_dur_sec=float(arg("min_dur_sec") if arg("min_dur_sec") is not None else cfg("min_dur_sec", manifest_defaults.get("min_dur_sec", 0.5))),
         conf=float(arg("conf") if arg("conf") is not None else cfg("conf", 0.25)),
-        imgsz=int(arg("imgsz") if arg("imgsz") is not None else cfg("imgsz", manifest_defaults.get("imgsz", 1920))),
+        imgsz=int(arg("imgsz") if arg("imgsz") is not None else cfg("imgsz", manifest_defaults.get("imgsz", 960))),
         start_time=int(arg("start_time") if arg("start_time") is not None else cfg("start_time", 0)),
         duration=int(arg("duration") if arg("duration") is not None else cfg("duration", 999999)),
     )
@@ -281,10 +281,7 @@ def run_pipeline(cfg: RunConfig) -> int:
         pre = DataPreprocessor(save_court_masks=False)
         pre.preprocess_single_video(raw_npz, str(cfg.video_path), str(preprocessed_npz), overwrite=True)
 
-        try:
-            fe = FeatureEngineer(target_fps=float(cfg.fps))
-        except TypeError:
-            fe = FeatureEngineer()
+        fe = FeatureEngineer(target_fps=float(cfg.fps))
         fe.create_features_from_preprocessed(str(preprocessed_npz), str(features_npz), overwrite=True)
 
         with np.load(str(features_npz)) as data:

--- a/src/extraction/pose_extractor.py
+++ b/src/extraction/pose_extractor.py
@@ -22,10 +22,11 @@ class PoseExtractor:
     and saves compressed npz artifacts. Designed for reuse by CLI and GUI.
     """
 
-    def __init__(self, model_dir: Optional[str] = None, model_path: str = "yolov8s-pose.pt") -> None:
+    def __init__(self, model_dir: Optional[str] = None, model_path: str = "yolov8s-pose.pt", imgsz: int = 1920) -> None:
         # Set early so downstream checks can use it
         self.model_path = model_path
         self.model_dir = model_dir
+        self.imgsz = int(imgsz)
 
         profile = os.environ.get("PIPELINE_PROFILE", "").strip().lower()
         if not profile:
@@ -118,10 +119,12 @@ class PoseExtractor:
         start_time_seconds: int = 0,
         duration_seconds: int = 60,
         target_fps: int = 15,
+        imgsz: Optional[int] = None,
         annotations_csv: Optional[str] = None,
         progress_callback: Optional[Callable[[float], None]] = None,
     ) -> str:
         import csv
+        predict_imgsz = int(self.imgsz if imgsz is None else imgsz)
 
         annotations = None
         if annotations_csv and annotations_csv != "None" and os.path.exists(annotations_csv):
@@ -181,7 +184,7 @@ class PoseExtractor:
                     verbose=False,
                     device=self.device,
                     conf=confidence_threshold,
-                    imgsz=1920,
+                    imgsz=predict_imgsz,
                     batch=self.batch_size,
                 )
             except TypeError:
@@ -190,26 +193,29 @@ class PoseExtractor:
                     verbose=False,
                     device=self.device,
                     conf=confidence_threshold,
-                    imgsz=1920,
+                    imgsz=predict_imgsz,
                 )
             for i, res in enumerate(results):
                 idx = batch_indices[i]
                 frame_data = {}
                 if res is not None and getattr(res, "boxes", None) is not None:
                     try:
-                        frame_data["boxes"] = res.boxes.xyxy.detach().cpu().numpy()
+                        frame_data["boxes"] = res.boxes.xyxy.detach().cpu().numpy().astype(np.float32)
+                        frame_data["box_conf"] = res.boxes.conf.detach().cpu().numpy().astype(np.float32)
                     except Exception:
-                        frame_data["boxes"] = np.array([])
+                        frame_data["boxes"] = np.empty((0, 4), dtype=np.float32)
+                        frame_data["box_conf"] = np.empty((0,), dtype=np.float32)
                     try:
-                        frame_data["keypoints"] = res.keypoints.xy.detach().cpu().numpy()
-                        frame_data["conf"] = res.keypoints.conf.detach().cpu().numpy()
+                        frame_data["keypoints"] = res.keypoints.xy.detach().cpu().numpy().astype(np.float32)
+                        frame_data["conf"] = res.keypoints.conf.detach().cpu().numpy().astype(np.float32)
                     except Exception:
-                        frame_data["keypoints"] = np.array([])
-                        frame_data["conf"] = np.array([])
+                        frame_data["keypoints"] = np.empty((0, 17, 2), dtype=np.float32)
+                        frame_data["conf"] = np.empty((0, 17), dtype=np.float32)
                 else:
-                    frame_data["boxes"] = np.array([])
-                    frame_data["keypoints"] = np.array([])
-                    frame_data["conf"] = np.array([])
+                    frame_data["boxes"] = np.empty((0, 4), dtype=np.float32)
+                    frame_data["box_conf"] = np.empty((0,), dtype=np.float32)
+                    frame_data["keypoints"] = np.empty((0, 17, 2), dtype=np.float32)
+                    frame_data["conf"] = np.empty((0, 17), dtype=np.float32)
                 frame_data["annotation_status"] = all_frames_data[idx].get("annotation_status", 0)
                 all_frames_data[idx] = frame_data
             batch_frames = []
@@ -236,9 +242,10 @@ class PoseExtractor:
                     if (starts[annotation_index] - EPS) <= current_timestamp <= (ends[annotation_index] + EPS):
                         annotation_status_current = 1
                 all_frames_data.append({
-                    "boxes": np.array([]),
-                    "keypoints": np.array([]),
-                    "conf": np.array([]),
+                    "boxes": np.empty((0, 4), dtype=np.float32),
+                    "box_conf": np.empty((0,), dtype=np.float32),
+                    "keypoints": np.empty((0, 17, 2), dtype=np.float32),
+                    "conf": np.empty((0, 17), dtype=np.float32),
                     "annotation_status": annotation_status_current,
                 })
                 batch_frames.append(frame)
@@ -275,7 +282,13 @@ class PoseExtractor:
                         pass
                     last_report_time = now
             else:
-                frame_data = {"boxes": np.array([]), "keypoints": np.array([]), "conf": np.array([]), "annotation_status": -1}
+                frame_data = {
+                    "boxes": np.empty((0, 4), dtype=np.float32),
+                    "box_conf": np.empty((0,), dtype=np.float32),
+                    "keypoints": np.empty((0, 17, 2), dtype=np.float32),
+                    "conf": np.empty((0, 17), dtype=np.float32),
+                    "annotation_status": -1,
+                }
             if not appended:
                 all_frames_data.append(frame_data)
 

--- a/src/features/feature_engineer.py
+++ b/src/features/feature_engineer.py
@@ -2,12 +2,20 @@ import os
 import logging
 import numpy as np
 
+from training.features.v1 import FeatureSetV1
+
 
 class FeatureEngineer:
-    def __init__(self, screen_width: int = 1280, screen_height: int = 720, feature_vector_size: int = 288) -> None:
+    def __init__(self, screen_width: int = 1280, screen_height: int = 720, feature_vector_size: int | None = None, target_fps: float = 5.0) -> None:
         self.screen_width = screen_width
         self.screen_height = screen_height
-        self.feature_vector_size = feature_vector_size
+        self.feature_set = FeatureSetV1(screen_width=screen_width, screen_height=screen_height)
+        expected_dim = self.feature_set.feature_dim()
+        if feature_vector_size is not None and feature_vector_size != expected_dim:
+            logging.warning("Ignoring legacy runtime feature size %s; v1 requires %s", feature_vector_size, expected_dim)
+        self.feature_vector_size = expected_dim
+        self.target_fps = float(target_fps)
+        self.dt = 1.0 / self.target_fps if self.target_fps > 0 else 1.0
         self.screen_center_x = screen_width / 2
 
     def _calculate_centroid(self, box):
@@ -34,6 +42,49 @@ class FeatureEngineer:
             return np.zeros((17, 2))
         return (current_keypoints - previous_keypoints) / dt
 
+    def _pack_player(self, player_data, num_keypoints: int = 17):
+        if player_data is None:
+            return {
+                "exists": False,
+                "box": np.full((4,), -1.0, dtype=np.float32),
+                "keypoints": np.full((num_keypoints, 2), -1.0, dtype=np.float32),
+                "conf": np.full((num_keypoints,), -1.0, dtype=np.float32),
+                "box_conf": -1.0,
+            }
+        return {
+            "exists": True,
+            "box": np.asarray(player_data["box"], dtype=np.float32),
+            "keypoints": np.asarray(player_data["keypoints"], dtype=np.float32),
+            "conf": np.asarray(player_data["conf"], dtype=np.float32),
+            "box_conf": float(player_data.get("box_conf", -1.0)),
+        }
+
+    def _normalize_prev_motion(self, previous_velocities):
+        if not previous_velocities:
+            return None
+        if "near" in previous_velocities or "far" in previous_velocities:
+            return previous_velocities
+        return {
+            "near": previous_velocities.get("near_player"),
+            "far": previous_velocities.get("far_player"),
+        }
+
+    def _player_velocity(self, player_data, previous_player_data):
+        if player_data is None or previous_player_data is None:
+            return None
+        centroid = self._calculate_centroid(player_data["box"])
+        prev_centroid = self._calculate_centroid(previous_player_data["box"])
+        return self._calculate_velocity(centroid, prev_centroid, self.dt)
+
+    def _player_keypoint_velocity(self, player_data, previous_player_data):
+        if player_data is None or previous_player_data is None:
+            return None
+        return self._calculate_keypoint_velocity(
+            np.asarray(player_data["keypoints"], dtype=np.float32),
+            np.asarray(previous_player_data["keypoints"], dtype=np.float32),
+            self.dt,
+        )
+
     def _calculate_limb_lengths(self, keypoints):
         if keypoints is None:
             return np.full(14, -1.0)
@@ -51,92 +102,20 @@ class FeatureEngineer:
         return np.array(limb_lengths)
 
     def create_feature_vector(self, assigned_players, previous_assigned_players=None, previous_velocities=None, num_keypoints: int = 17):
-        features_per_player = 1 + 4 + 2 + 2 + 2 + 1 + 1 + (num_keypoints * 3) + (num_keypoints * 2) + (num_keypoints * 2) + num_keypoints + num_keypoints + 14
-        vector = np.full(features_per_player * 2, -1.0)
-
-        if assigned_players['near_player']:
-            player_data = assigned_players['near_player']
-            vector[0] = 1.0
-            centroid = self._calculate_centroid(player_data['box'])
-            velocity = (0.0, 0.0)
-            acceleration = (0.0, 0.0)
-            speed = -1.0
-            acceleration_magnitude = -1.0
-            kp_velocities = np.zeros((num_keypoints, 2))
-            kp_accelerations = np.zeros((num_keypoints, 2))
-            kp_speeds = np.full(num_keypoints, -1.0)
-            kp_acceleration_magnitudes = np.full(num_keypoints, -1.0)
-            limb_lengths = np.full(14, -1.0)
-            if (previous_assigned_players and previous_assigned_players['near_player']):
-                prev_centroid = self._calculate_centroid(previous_assigned_players['near_player']['box'])
-                velocity = self._calculate_velocity(centroid, prev_centroid)
-                speed = np.sqrt(velocity[0]**2 + velocity[1]**2)
-                if previous_velocities and previous_velocities['near_player']:
-                    acceleration = self._calculate_acceleration(velocity, previous_velocities['near_player'])
-                    acceleration_magnitude = np.sqrt(acceleration[0]**2 + acceleration[1]**2)
-                current_kps = player_data['keypoints']
-                prev_kps = previous_assigned_players['near_player']['keypoints']
-                kp_velocities = self._calculate_keypoint_velocity(current_kps, prev_kps)
-                kp_speeds = np.sqrt(kp_velocities[:, 0]**2 + kp_velocities[:, 1]**2)
-                kp_acceleration_magnitudes = np.sqrt(kp_accelerations[:, 0]**2 + kp_accelerations[:, 1]**2)
-                limb_lengths = self._calculate_limb_lengths(player_data['keypoints'])
-            flat_features = np.concatenate([
-                player_data['box'], centroid, velocity, acceleration, [speed, acceleration_magnitude],
-                player_data['keypoints'].flatten(), player_data['conf'], kp_velocities.flatten(), kp_accelerations.flatten(),
-                kp_speeds, kp_acceleration_magnitudes, limb_lengths
-            ])
-            vector[1:features_per_player] = flat_features
-        else:
-            offset = 1 + 4 + 2
-            vector[offset:offset+4] = [0.0, 0.0, 0.0, 0.0]
-            vector[offset+4:offset+6] = [-1.0, -1.0]
-            kp_offset = offset + 6 + (num_keypoints * 3)
-            vector[kp_offset:kp_offset+(num_keypoints * 4)] = 0.0
-            mag_offset = kp_offset + (num_keypoints * 4)
-            vector[mag_offset:mag_offset+(num_keypoints * 2)] = -1.0
-
-        offset = features_per_player
-        if assigned_players['far_player']:
-            player_data = assigned_players['far_player']
-            vector[offset] = 1.0
-            centroid = self._calculate_centroid(player_data['box'])
-            velocity = (0.0, 0.0)
-            acceleration = (0.0, 0.0)
-            speed = -1.0
-            acceleration_magnitude = -1.0
-            kp_velocities = np.zeros((num_keypoints, 2))
-            kp_accelerations = np.zeros((num_keypoints, 2))
-            kp_speeds = np.full(num_keypoints, -1.0)
-            kp_acceleration_magnitudes = np.full(num_keypoints, -1.0)
-            limb_lengths = np.full(14, -1.0)
-            if (previous_assigned_players and previous_assigned_players['far_player']):
-                prev_centroid = self._calculate_centroid(previous_assigned_players['far_player']['box'])
-                velocity = self._calculate_velocity(centroid, prev_centroid)
-                speed = np.sqrt(velocity[0]**2 + velocity[1]**2)
-                if previous_velocities and previous_velocities['far_player']:
-                    acceleration = self._calculate_acceleration(velocity, previous_velocities['far_player'])
-                    acceleration_magnitude = np.sqrt(acceleration[0]**2 + acceleration[1]**2)
-                current_kps = player_data['keypoints']
-                prev_kps = previous_assigned_players['far_player']['keypoints']
-                kp_velocities = self._calculate_keypoint_velocity(current_kps, prev_kps)
-                kp_speeds = np.sqrt(kp_velocities[:, 0]**2 + kp_velocities[:, 1]**2)
-                kp_acceleration_magnitudes = np.sqrt(kp_accelerations[:, 0]**2 + kp_accelerations[:, 1]**2)
-                limb_lengths = self._calculate_limb_lengths(player_data['keypoints'])
-            flat_features = np.concatenate([
-                player_data['box'], centroid, velocity, acceleration, [speed, acceleration_magnitude],
-                player_data['keypoints'].flatten(), player_data['conf'], kp_velocities.flatten(), kp_accelerations.flatten(),
-                kp_speeds, kp_acceleration_magnitudes, limb_lengths
-            ])
-            vector[offset+1 : offset+self.feature_vector_size] = flat_features
-        else:
-            pos_offset = offset + 1 + 4 + 2
-            vector[pos_offset:pos_offset+4] = [0.0, 0.0, 0.0, 0.0]
-            vector[pos_offset+4:pos_offset+6] = [-1.0, -1.0]
-            kp_offset = pos_offset + 6 + (num_keypoints * 3)
-            vector[kp_offset:kp_offset+(num_keypoints * 4)] = 0.0
-            mag_offset = kp_offset + (num_keypoints * 4)
-            vector[mag_offset:mag_offset+(num_keypoints * 2)] = -1.0
-        return vector
+        previous_assigned_players = previous_assigned_players or {}
+        near = self._pack_player(assigned_players.get('near_player'), num_keypoints)
+        far = self._pack_player(assigned_players.get('far_player'), num_keypoints)
+        prev_near = self._pack_player(previous_assigned_players.get('near_player'), num_keypoints) if previous_assigned_players else None
+        prev_far = self._pack_player(previous_assigned_players.get('far_player'), num_keypoints) if previous_assigned_players else None
+        return self.feature_set.build_feature_vector(
+            near,
+            far,
+            prev_near,
+            prev_far,
+            self._normalize_prev_motion(previous_velocities),
+            self.dt,
+            num_keypoints=num_keypoints,
+        )
 
     def create_features_from_preprocessed(self, input_npz_path: str, output_file: str, overwrite: bool = False) -> bool:
         try:
@@ -144,36 +123,51 @@ class FeatureEngineer:
                 logging.info("Features skip (exists): %s", os.path.basename(output_file))
                 return True
             logging.info("Loading preprocessed data from: %s", input_npz_path)
-            data = np.load(input_npz_path, allow_pickle=True)
-            frames = data['frames']
-            targets = data['targets']
-            near_players = data['near_players']
-            far_players = data['far_players']
+            with np.load(input_npz_path, allow_pickle=True) as data:
+                targets = data['targets'].copy()
+                near_players = data['near_players'].copy()
+                far_players = data['far_players'].copy()
             annotated_indices = np.where(targets >= 0)[0]
             feature_vectors, feature_targets = [], []
             previous_players = None
-            previous_velocities = {'near_player': None, 'far_player': None}
+            previous_velocities = {
+                'near': {'centroid': None, 'keypoints': None},
+                'far': {'centroid': None, 'keypoints': None},
+            }
             for idx in annotated_indices:
                 assigned_players = {'near_player': near_players[idx], 'far_player': far_players[idx]}
                 feature_vector = self.create_feature_vector(assigned_players, previous_players, previous_velocities)
                 feature_vectors.append(feature_vector)
                 feature_targets.append(targets[idx])
-                current_velocities = {'near_player': None, 'far_player': None}
-                if (assigned_players['near_player'] and previous_players and previous_players['near_player']):
-                    current_centroid = self._calculate_centroid(assigned_players['near_player']['box'])
-                    prev_centroid = self._calculate_centroid(previous_players['near_player']['box'])
-                    current_velocities['near_player'] = self._calculate_velocity(current_centroid, prev_centroid)
-                if (assigned_players['far_player'] and previous_players and previous_players['far_player']):
-                    current_centroid = self._calculate_centroid(assigned_players['far_player']['box'])
-                    prev_centroid = self._calculate_centroid(previous_players['far_player']['box'])
-                    current_velocities['far_player'] = self._calculate_velocity(current_centroid, prev_centroid)
+                current_velocities = {
+                    'near': {
+                        'centroid': self._player_velocity(
+                            assigned_players['near_player'],
+                            previous_players['near_player'] if previous_players else None,
+                        ),
+                        'keypoints': self._player_keypoint_velocity(
+                            assigned_players['near_player'],
+                            previous_players['near_player'] if previous_players else None,
+                        ),
+                    },
+                    'far': {
+                        'centroid': self._player_velocity(
+                            assigned_players['far_player'],
+                            previous_players['far_player'] if previous_players else None,
+                        ),
+                        'keypoints': self._player_keypoint_velocity(
+                            assigned_players['far_player'],
+                            previous_players['far_player'] if previous_players else None,
+                        ),
+                    },
+                }
                 previous_players = assigned_players
                 previous_velocities = current_velocities
             if feature_vectors:
-                feature_array = np.array(feature_vectors)
+                feature_array = np.array(feature_vectors, dtype=np.float32)
                 target_array = np.array(feature_targets)
             else:
-                feature_array = np.empty((0, self.feature_vector_size))
+                feature_array = np.empty((0, self.feature_vector_size), dtype=np.float32)
                 target_array = np.empty((0,))
             os.makedirs(os.path.dirname(output_file), exist_ok=True)
             np.savez_compressed(output_file, features=feature_array, targets=target_array)

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -124,6 +124,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "high": 0.7,
     "min_dur_sec": 1.0,
     "conf": 0.25,
+    "imgsz": 960,
     "start_time": 0,
     "duration": 999999,
 }
@@ -135,6 +136,7 @@ ADVANCED_WARNINGS = {
     "low": "Lowering thresholds increases sensitivity and false positives.",
     "high": "Raising thresholds decreases sensitivity but may miss points.",
     "min_dur_sec": "Shorter durations may create noisy/short segments.",
+    "imgsz": "YOLO image size affects pose recall and runtime; v0.3.1 was exported with 960.",
 }
 
 app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path="/")
@@ -344,6 +346,7 @@ def _run_pipeline(job_id: str) -> None:
             start_time_seconds=int(cfg["start_time"]),
             duration_seconds=int(cfg["duration"]),
             target_fps=int(cfg["fps"]),
+            imgsz=int(cfg.get("imgsz", 1920)),
             annotations_csv=None,
             progress_callback=pose_progress,
         )
@@ -362,7 +365,7 @@ def _run_pipeline(job_id: str) -> None:
 
         _check_cancel(job)
         _set_step(job, "feature", "in_progress", 5)
-        fe = FeatureEngineer()
+        fe = FeatureEngineer(target_fps=float(cfg["fps"]))
         features_npz = str(job_dir / "features.npz")
         success_fe = fe.create_features_from_preprocessed(preprocessed_npz, features_npz, overwrite=True)
         if not success_fe or not Path(features_npz).exists():
@@ -372,8 +375,8 @@ def _run_pipeline(job_id: str) -> None:
 
         _check_cancel(job)
         _set_step(job, "inference", "in_progress", 5)
-        data = np.load(features_npz)
-        features = data["features"]
+        with np.load(features_npz) as data:
+            features = data["features"].copy()
         scaler = load_scaler_asset(str(scaler_path))
         features = scaler.transform(features)
 

--- a/src/preprocessing/data_preprocessor.py
+++ b/src/preprocessing/data_preprocessor.py
@@ -27,10 +27,19 @@ class DataPreprocessor:
         union_area = box1_area + box2_area - inter_area
         return inter_area / union_area if union_area > 0 else 0
 
-    def _conditional_merge_boxes(self, boxes, keypoints, confs):
+    def _conditional_merge_boxes(self, boxes, keypoints, confs, box_conf):
         if len(boxes) <= 1:
-            return boxes, keypoints, confs
-        detections = [{'box': boxes[i], 'keypoints': keypoints[i], 'conf': confs[i], 'clump_id': -1} for i in range(len(boxes))]
+            return boxes, keypoints, confs, box_conf
+        detections = [
+            {
+                'box': boxes[i],
+                'keypoints': keypoints[i],
+                'conf': confs[i],
+                'box_conf': box_conf[i],
+                'clump_id': -1,
+            }
+            for i in range(len(boxes))
+        ]
         clump_count = 0
         for i in range(len(detections)):
             if detections[i]['clump_id'] == -1:
@@ -40,14 +49,15 @@ class DataPreprocessor:
                         detections[j]['clump_id'] = clump_count
                 clump_count += 1
         if clump_count == len(detections):
-            return boxes, keypoints, confs
-        final_boxes, final_keypoints, final_confs = [], [], []
+            return boxes, keypoints, confs, box_conf
+        final_boxes, final_keypoints, final_confs, final_box_conf = [], [], [], []
         for clump_id in range(clump_count):
             clump = [d for d in detections if d['clump_id'] == clump_id]
             if len(clump) == 1:
                 final_boxes.append(clump[0]['box'])
                 final_keypoints.append(clump[0]['keypoints'])
                 final_confs.append(clump[0]['conf'])
+                final_box_conf.append(clump[0]['box_conf'])
                 continue
             min_x1 = min(d['box'][0] for d in clump)
             min_y1 = min(d['box'][1] for d in clump)
@@ -65,22 +75,35 @@ class DataPreprocessor:
                 final_boxes.append(merged_box)
                 final_keypoints.append(best_detection['keypoints'])
                 final_confs.append(best_detection['conf'])
+                final_box_conf.append(best_detection['box_conf'])
             else:
                 for d in clump:
                     final_boxes.append(d['box'])
                     final_keypoints.append(d['keypoints'])
                     final_confs.append(d['conf'])
-        return np.array(final_boxes), np.array(final_keypoints), np.array(final_confs)
+                    final_box_conf.append(d['box_conf'])
+        return np.array(final_boxes), np.array(final_keypoints), np.array(final_confs), np.array(final_box_conf)
 
     def assign_players(self, frame_data):
-        boxes = frame_data.get('boxes', np.array([]))
-        keypoints = frame_data.get('keypoints', np.array([]))
-        confs = frame_data.get('conf', np.array([]))
-        clean_boxes, clean_keypoints, clean_confs = self._conditional_merge_boxes(boxes, keypoints, confs)
+        boxes = np.asarray(frame_data.get('boxes', np.empty((0, 4), dtype=np.float32)), dtype=np.float32)
+        keypoints = np.asarray(frame_data.get('keypoints', np.empty((0, 17, 2), dtype=np.float32)), dtype=np.float32)
+        confs = np.asarray(frame_data.get('conf', np.empty((0, 17), dtype=np.float32)), dtype=np.float32)
+        box_conf = np.asarray(frame_data.get('box_conf', np.full((len(boxes),), -1.0, dtype=np.float32)), dtype=np.float32)
+        if box_conf.shape[0] != len(boxes):
+            box_conf = np.full((len(boxes),), -1.0, dtype=np.float32)
+        clean_boxes, clean_keypoints, clean_confs, clean_box_conf = self._conditional_merge_boxes(boxes, keypoints, confs, box_conf)
         assigned_players = {'near_player': None, 'far_player': None}
         if len(clean_boxes) == 0:
             return assigned_players
-        candidates = [{'box': clean_boxes[i], 'keypoints': clean_keypoints[i], 'conf': clean_confs[i]} for i in range(len(clean_boxes))]
+        candidates = [
+            {
+                'box': clean_boxes[i],
+                'keypoints': clean_keypoints[i],
+                'conf': clean_confs[i],
+                'box_conf': clean_box_conf[i],
+            }
+            for i in range(len(clean_boxes))
+        ]
         near_player_idx = max(range(len(candidates)), key=lambda i: candidates[i]['box'][3])
         near_player = candidates[near_player_idx]
         assigned_players['near_player'] = near_player
@@ -101,20 +124,36 @@ class DataPreprocessor:
             return None
 
     def filter_frame_by_court(self, frame_data, mask):
+        boxes = np.asarray(frame_data.get('boxes', np.empty((0, 4), dtype=np.float32)), dtype=np.float32)
+        keypoints = np.asarray(frame_data.get('keypoints', np.empty((0, 17, 2), dtype=np.float32)), dtype=np.float32)
+        conf = np.asarray(frame_data.get('conf', np.empty((0, 17), dtype=np.float32)), dtype=np.float32)
+        box_conf = frame_data.get('box_conf', np.full((len(boxes),), -1.0, dtype=np.float32))
+        box_conf = np.asarray(box_conf, dtype=np.float32)
+        if box_conf.shape[0] != len(boxes):
+            box_conf = np.full((len(boxes),), -1.0, dtype=np.float32)
+        normalized = {
+            'boxes': boxes.reshape((-1, 4)),
+            'box_conf': box_conf,
+            'keypoints': keypoints.reshape((-1, 17, 2)),
+            'conf': conf.reshape((-1, 17)),
+        }
         if mask is None:
-            return frame_data
-        boxes = frame_data['boxes']
-        keypoints = frame_data['keypoints']
-        conf = frame_data['conf']
-        kept_boxes, kept_keypoints, kept_conf = [], [], []
-        for i, box in enumerate(boxes):
+            return normalized
+        kept_boxes, kept_box_conf, kept_keypoints, kept_conf = [], [], [], []
+        for i, box in enumerate(normalized['boxes']):
             center_x = (box[0] + box[2]) / 2
             center_y = (box[1] + box[3]) / 2
             if (0 <= center_y < mask.shape[0] and 0 <= center_x < mask.shape[1] and mask[int(center_y), int(center_x)] == 0):
                 kept_boxes.append(box)
-                kept_keypoints.append(keypoints[i])
-                kept_conf.append(conf[i])
-        return { 'boxes': np.array(kept_boxes), 'keypoints': np.array(kept_keypoints), 'conf': np.array(kept_conf) }
+                kept_box_conf.append(normalized['box_conf'][i])
+                kept_keypoints.append(normalized['keypoints'][i])
+                kept_conf.append(normalized['conf'][i])
+        return {
+            'boxes': np.asarray(kept_boxes, dtype=np.float32).reshape((-1, 4)),
+            'box_conf': np.asarray(kept_box_conf, dtype=np.float32),
+            'keypoints': np.asarray(kept_keypoints, dtype=np.float32).reshape((-1, 17, 2)),
+            'conf': np.asarray(kept_conf, dtype=np.float32).reshape((-1, 17)),
+        }
 
     def preprocess_single_video(self, input_npz_path: str, video_path: str, output_npz_path: str, overwrite: bool = False) -> bool:
         try:
@@ -122,7 +161,8 @@ class DataPreprocessor:
                 logging.info("Preprocess skip (exists): %s", os.path.basename(output_npz_path))
                 return True
             logging.info("Loading pose data from: %s", input_npz_path)
-            pose_data = np.load(input_npz_path, allow_pickle=True)['frames']
+            with np.load(input_npz_path, allow_pickle=True) as data:
+                pose_data = data['frames'].copy()
             logging.info("Loaded %s frames", len(pose_data))
             logging.info("Generating court mask from: %s", video_path)
             mask = self.generate_court_mask(video_path)
@@ -135,7 +175,12 @@ class DataPreprocessor:
                 annotation_status = frame_data.get('annotation_status', 0)
                 all_targets.append(annotation_status)
                 if annotation_status == -1:
-                    all_frame_data.append({'boxes': np.array([]), 'keypoints': np.array([]), 'conf': np.array([])})
+                    all_frame_data.append({
+                        'boxes': np.empty((0, 4), dtype=np.float32),
+                        'box_conf': np.empty((0,), dtype=np.float32),
+                        'keypoints': np.empty((0, 17, 2), dtype=np.float32),
+                        'conf': np.empty((0, 17), dtype=np.float32),
+                    })
                     all_near_players.append(None)
                     all_far_players.append(None)
                     continue

--- a/src/training/pose/yolo_hdf5.py
+++ b/src/training/pose/yolo_hdf5.py
@@ -357,8 +357,8 @@ class YoloHdf5Extractor:
         model_path: str,
         conf: float,
         imgsz: int,
-        sampling_mode: str,
-        sample_fps: Optional[float],
+        sampling_mode: str = "full_rate",
+        sample_fps: Optional[float] = None,
     ) -> None:
         expected = {
             "video_path": str(video_path),

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers for RallyClip runtime contract tests."""

--- a/tests/helpers/module_stubs.py
+++ b/tests/helpers/module_stubs.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import numpy as np
+
+
+def import_cli_main_with_stubs(monkeypatch):
+    _drop_modules("cli.main")
+
+    infer = types.ModuleType("infer")
+    infer.extract_segments_from_binary = _extract_segments_from_binary
+    infer.gaussian_filter1d = lambda values, sigma: values
+    infer.hysteresis_threshold = _hysteresis_threshold
+    infer.load_scaler_asset = lambda path: None
+    infer.load_model_from_checkpoint = lambda path, return_logits=False: (None, None)
+    infer.run_windowed_inference_average_onnx = lambda *args, **kwargs: np.array([], dtype=np.float32)
+    infer.run_windowed_inference_average = lambda *args, **kwargs: np.array([], dtype=np.float32)
+    infer.write_segments_csv = lambda *args, **kwargs: None
+
+    extraction_pose = types.ModuleType("extraction.pose_extractor")
+    extraction_pose.PoseExtractor = object
+
+    features_engineer = types.ModuleType("features.feature_engineer")
+    features_engineer.FeatureEngineer = object
+
+    preprocessing_data = types.ModuleType("preprocessing.data_preprocessor")
+    preprocessing_data.DataPreprocessor = object
+
+    segmentation_segment = types.ModuleType("segmentation.segment")
+    segmentation_segment.segment_video = lambda *args, **kwargs: None
+
+    monkeypatch.setitem(sys.modules, "infer", infer)
+    monkeypatch.setitem(sys.modules, "extraction.pose_extractor", extraction_pose)
+    monkeypatch.setitem(sys.modules, "features.feature_engineer", features_engineer)
+    monkeypatch.setitem(sys.modules, "preprocessing.data_preprocessor", preprocessing_data)
+    monkeypatch.setitem(sys.modules, "segmentation.segment", segmentation_segment)
+
+    return importlib.import_module("cli.main")
+
+
+def import_data_preprocessor_with_stubs(monkeypatch):
+    _drop_modules("preprocessing.data_preprocessor")
+    court_detector = types.ModuleType("preprocessing.court_detector")
+
+    class StubCourtDetector:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def process_video(self, *args, **kwargs):
+            return None, None, {}
+
+    court_detector.CourtDetector = StubCourtDetector
+    monkeypatch.setitem(sys.modules, "preprocessing.court_detector", court_detector)
+    return importlib.import_module("preprocessing.data_preprocessor")
+
+
+def import_pose_extractor_with_stubs(monkeypatch):
+    _drop_modules("extraction.pose_extractor")
+
+    av = types.ModuleType("av")
+    av.open = lambda path: None
+
+    ultralytics = types.ModuleType("ultralytics")
+    ultralytics.YOLO = lambda *args, **kwargs: None
+    ultralytics_utils = types.ModuleType("ultralytics.utils")
+    ultralytics_utils.SETTINGS = {}
+
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    torch.backends = types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: False))
+
+    monkeypatch.setitem(sys.modules, "av", av)
+    monkeypatch.setitem(sys.modules, "ultralytics", ultralytics)
+    monkeypatch.setitem(sys.modules, "ultralytics.utils", ultralytics_utils)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    return importlib.import_module("extraction.pose_extractor")
+
+
+def _drop_modules(*names: str) -> None:
+    for name in names:
+        sys.modules.pop(name, None)
+
+
+def _hysteresis_threshold(values: np.ndarray, low: float = 0.3, high: float = 0.7, min_duration: int = 0):
+    pred = np.zeros(len(values), dtype=np.int32)
+    active = False
+    start = None
+    for idx, value in enumerate(values):
+        if not active and value >= high:
+            active = True
+            start = idx
+        elif active and value < low:
+            if start is not None and idx - start >= min_duration:
+                pred[start:idx] = 1
+            active = False
+            start = None
+    if active and start is not None and len(values) - start >= min_duration:
+        pred[start:] = 1
+    return pred
+
+
+def _extract_segments_from_binary(pred: np.ndarray):
+    segments = []
+    in_segment = False
+    start = None
+    for idx, value in enumerate(pred):
+        if value and not in_segment:
+            in_segment = True
+            start = idx
+        elif not value and in_segment:
+            segments.append((start, idx))
+            in_segment = False
+            start = None
+    if in_segment:
+        segments.append((start, len(pred)))
+    return segments

--- a/tests/helpers/runtime_fixtures.py
+++ b/tests/helpers/runtime_fixtures.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+
+NUM_KEYPOINTS = 17
+FPS = 5.0
+DT = 1.0 / FPS
+FRAME_WIDTH = 1280
+FRAME_HEIGHT = 720
+PER_PLAYER_DIM = 181
+FEATURE_DIM = PER_PLAYER_DIM * 2
+
+EXISTS = slice(0, 1)
+BOX = slice(1, 5)
+CENTROID = slice(5, 7)
+VELOCITY = slice(7, 9)
+ACCELERATION = slice(9, 11)
+SPEED = 11
+ACCELERATION_MAGNITUDE = 12
+KEYPOINTS = slice(13, 47)
+KEYPOINT_CONFIDENCE = slice(47, 64)
+KEYPOINT_VELOCITY = slice(64, 98)
+KEYPOINT_ACCELERATION = slice(98, 132)
+KEYPOINT_SPEED = slice(132, 149)
+KEYPOINT_ACCELERATION_MAGNITUDE = slice(149, 166)
+LIMB_LENGTHS = slice(166, 180)
+BOX_CONFIDENCE = 180
+
+LIMB_CONNECTIONS = [
+    (5, 7),
+    (7, 9),
+    (6, 8),
+    (8, 10),
+    (11, 13),
+    (13, 15),
+    (12, 14),
+    (14, 16),
+    (5, 6),
+    (11, 12),
+    (5, 11),
+    (6, 12),
+    (6, 5),
+    (12, 11),
+]
+
+NEAR_BOXES = [
+    np.array([100.0, 400.0, 140.0, 500.0], dtype=np.float32),
+    np.array([110.0, 400.0, 150.0, 500.0], dtype=np.float32),
+    np.array([130.0, 405.0, 170.0, 505.0], dtype=np.float32),
+]
+FAR_BOXES = [
+    np.array([600.0, 200.0, 630.0, 260.0], dtype=np.float32),
+    np.array([595.0, 202.0, 625.0, 262.0], dtype=np.float32),
+    np.array([585.0, 206.0, 615.0, 266.0], dtype=np.float32),
+]
+NEAR_KEYPOINT_DELTAS = [
+    np.array([0.0, 0.0], dtype=np.float32),
+    np.array([2.0, 1.0], dtype=np.float32),
+    np.array([5.0, 3.0], dtype=np.float32),
+]
+FAR_KEYPOINT_DELTAS = [
+    np.array([0.0, 0.0], dtype=np.float32),
+    np.array([-1.0, 2.0], dtype=np.float32),
+    np.array([-3.0, 5.0], dtype=np.float32),
+]
+NEAR_BOX_CONF = [0.90, 0.91, 0.92]
+FAR_BOX_CONF = [0.70, 0.71, 0.72]
+
+
+class FakeTensor:
+    def __init__(self, value: Iterable[float] | np.ndarray) -> None:
+        self._value = np.asarray(value, dtype=np.float32)
+
+    def detach(self) -> "FakeTensor":
+        return self
+
+    def cpu(self) -> "FakeTensor":
+        return self
+
+    def numpy(self) -> np.ndarray:
+        return self._value
+
+
+@dataclass
+class FakeBoxes:
+    xyxy: FakeTensor
+    conf: FakeTensor
+
+
+@dataclass
+class FakeKeypoints:
+    xy: FakeTensor
+    conf: FakeTensor
+
+
+@dataclass
+class FakeYoloResult:
+    boxes: FakeBoxes
+    keypoints: FakeKeypoints
+
+
+class RecordingFakeYoloModel:
+    def __init__(self, results: list[FakeYoloResult], fail_on_batch: bool = False) -> None:
+        self.results = results
+        self.fail_on_batch = fail_on_batch
+        self.predict_calls: list[dict] = []
+
+    def predict(self, **kwargs):
+        self.predict_calls.append(kwargs)
+        if self.fail_on_batch and "batch" in kwargs:
+            raise TypeError("batch is not supported by this fake model")
+        return self.results
+
+
+def keypoints(base_x: float, base_y: float, delta: np.ndarray) -> np.ndarray:
+    values = np.zeros((NUM_KEYPOINTS, 2), dtype=np.float32)
+    for idx in range(NUM_KEYPOINTS):
+        values[idx] = [base_x + idx + delta[0], base_y + (idx * 2) + delta[1]]
+    return values
+
+
+def confidence(start: float) -> np.ndarray:
+    return np.linspace(start, start + 0.16, NUM_KEYPOINTS, dtype=np.float32)
+
+
+def make_player(side: str, frame_idx: int) -> dict:
+    if side == "near":
+        return {
+            "exists": True,
+            "box": NEAR_BOXES[frame_idx].copy(),
+            "keypoints": keypoints(100.0, 410.0, NEAR_KEYPOINT_DELTAS[frame_idx]),
+            "conf": confidence(0.50),
+            "box_conf": float(NEAR_BOX_CONF[frame_idx]),
+        }
+    if side == "far":
+        return {
+            "exists": True,
+            "box": FAR_BOXES[frame_idx].copy(),
+            "keypoints": keypoints(600.0, 210.0, FAR_KEYPOINT_DELTAS[frame_idx]),
+            "conf": confidence(0.60),
+            "box_conf": float(FAR_BOX_CONF[frame_idx]),
+        }
+    raise ValueError(f"Unknown side: {side}")
+
+
+def absent_player() -> dict:
+    return {"exists": False}
+
+
+def make_runtime_assigned_players(frame_idx: int, near: bool = True, far: bool = True) -> dict:
+    return {
+        "near_player": runtime_player(make_player("near", frame_idx)) if near else None,
+        "far_player": runtime_player(make_player("far", frame_idx)) if far else None,
+    }
+
+
+def runtime_player(player: dict) -> dict:
+    return {
+        "box": player["box"],
+        "keypoints": player["keypoints"],
+        "conf": player["conf"],
+        "box_conf": player["box_conf"],
+    }
+
+
+def fake_yolo_result(frame_idx: int, include_far: bool = True) -> FakeYoloResult:
+    players = [make_player("near", frame_idx)]
+    if include_far:
+        players.append(make_player("far", frame_idx))
+    return FakeYoloResult(
+        boxes=FakeBoxes(
+            xyxy=FakeTensor(np.stack([p["box"] for p in players])),
+            conf=FakeTensor(np.array([p["box_conf"] for p in players], dtype=np.float32)),
+        ),
+        keypoints=FakeKeypoints(
+            xy=FakeTensor(np.stack([p["keypoints"] for p in players])),
+            conf=FakeTensor(np.stack([p["conf"] for p in players])),
+        ),
+    )
+
+
+def expected_feature_sequence(frame_players: list[tuple[dict, dict]], dt: float = DT) -> np.ndarray:
+    vectors: list[np.ndarray] = []
+    prev_near = None
+    prev_far = None
+    prev_motion = {
+        "near": {"centroid": None, "keypoints": None},
+        "far": {"centroid": None, "keypoints": None},
+    }
+    for near, far in frame_players:
+        vector = np.concatenate(
+            [
+                expected_player_features(near, prev_near, prev_motion["near"], dt),
+                expected_player_features(far, prev_far, prev_motion["far"], dt),
+            ]
+        ).astype(np.float32)
+        vectors.append(vector)
+        prev_motion = {
+            "near": {
+                "centroid": player_velocity(near, prev_near, dt),
+                "keypoints": keypoint_velocity(near, prev_near, dt),
+            },
+            "far": {
+                "centroid": player_velocity(far, prev_far, dt),
+                "keypoints": keypoint_velocity(far, prev_far, dt),
+            },
+        }
+        prev_near = near
+        prev_far = far
+    return np.asarray(vectors, dtype=np.float32)
+
+
+def expected_player_features(player: dict, prev_player: dict | None, prev_motion: dict, dt: float) -> np.ndarray:
+    vector = np.full(PER_PLAYER_DIM, -1.0, dtype=np.float32)
+    if not player.get("exists", False):
+        vector[0] = 0.0
+        return vector
+
+    box = player["box"]
+    kps = player["keypoints"]
+    centroid = box_centroid(box)
+    velocity = np.zeros(2, dtype=np.float32)
+    acceleration = np.zeros(2, dtype=np.float32)
+    speed = -1.0
+    acceleration_magnitude = -1.0
+    kp_velocity = np.zeros((NUM_KEYPOINTS, 2), dtype=np.float32)
+    kp_acceleration = np.zeros((NUM_KEYPOINTS, 2), dtype=np.float32)
+    kp_speed = np.full(NUM_KEYPOINTS, -1.0, dtype=np.float32)
+    kp_acceleration_magnitude = np.full(NUM_KEYPOINTS, -1.0, dtype=np.float32)
+
+    if prev_player and prev_player.get("exists", False):
+        velocity = player_velocity(player, prev_player, dt)
+        speed = float(np.linalg.norm(velocity))
+        if prev_motion["centroid"] is not None:
+            acceleration = (velocity - np.asarray(prev_motion["centroid"], dtype=np.float32)) / dt
+            acceleration_magnitude = float(np.linalg.norm(acceleration))
+
+        kp_velocity = keypoint_velocity(player, prev_player, dt)
+        kp_speed = np.linalg.norm(kp_velocity, axis=1)
+        if prev_motion["keypoints"] is not None:
+            kp_acceleration = (kp_velocity - prev_motion["keypoints"]) / dt
+        kp_acceleration_magnitude = np.linalg.norm(kp_acceleration, axis=1)
+
+    vector[0] = 1.0
+    vector[BOX] = box
+    vector[CENTROID] = centroid
+    vector[VELOCITY] = velocity
+    vector[ACCELERATION] = acceleration
+    vector[SPEED] = speed
+    vector[ACCELERATION_MAGNITUDE] = acceleration_magnitude
+    vector[KEYPOINTS] = kps.flatten()
+    vector[KEYPOINT_CONFIDENCE] = player["conf"]
+    vector[KEYPOINT_VELOCITY] = kp_velocity.flatten()
+    vector[KEYPOINT_ACCELERATION] = kp_acceleration.flatten()
+    vector[KEYPOINT_SPEED] = kp_speed
+    vector[KEYPOINT_ACCELERATION_MAGNITUDE] = kp_acceleration_magnitude
+    vector[LIMB_LENGTHS] = limb_lengths(kps)
+    vector[BOX_CONFIDENCE] = player["box_conf"]
+    return vector
+
+
+def box_centroid(box: np.ndarray) -> np.ndarray:
+    return np.asarray([(box[0] + box[2]) / 2.0, (box[1] + box[3]) / 2.0], dtype=np.float32)
+
+
+def player_velocity(player: dict, prev_player: dict | None, dt: float) -> np.ndarray | None:
+    if not player.get("exists", False) or not prev_player or not prev_player.get("exists", False):
+        return None
+    return (box_centroid(player["box"]) - box_centroid(prev_player["box"])) / dt
+
+
+def keypoint_velocity(player: dict, prev_player: dict | None, dt: float) -> np.ndarray | None:
+    if not player.get("exists", False) or not prev_player or not prev_player.get("exists", False):
+        return None
+    return (player["keypoints"] - prev_player["keypoints"]) / dt
+
+
+def limb_lengths(kps: np.ndarray) -> np.ndarray:
+    return np.asarray([np.linalg.norm(kps[i] - kps[j]) for i, j in LIMB_CONNECTIONS], dtype=np.float32)
+
+
+def write_preprocessed_runtime_npz(path: Path, assigned_frames: list[dict]) -> Path:
+    frames = [{"boxes": np.empty((0, 4)), "keypoints": np.empty((0, 17, 2)), "conf": np.empty((0, 17))} for _ in assigned_frames]
+    targets = np.zeros(len(assigned_frames), dtype=np.int8)
+    near_players = np.asarray([frame["near_player"] for frame in assigned_frames], dtype=object)
+    far_players = np.asarray([frame["far_player"] for frame in assigned_frames], dtype=object)
+    np.savez_compressed(
+        path,
+        frames=np.asarray(frames, dtype=object),
+        targets=targets,
+        near_players=near_players,
+        far_players=far_players,
+    )
+    return path
+
+
+def write_raw_pose_npz(path: Path, results: list[FakeYoloResult]) -> Path:
+    frames = []
+    for result in results:
+        frames.append(
+            {
+                "boxes": result.boxes.xyxy.numpy(),
+                "box_conf": result.boxes.conf.numpy(),
+                "keypoints": result.keypoints.xy.numpy(),
+                "conf": result.keypoints.conf.numpy(),
+                "annotation_status": 0,
+            }
+        )
+    np.savez_compressed(path, frames=np.asarray(frames, dtype=object))
+    return path
+
+
+def write_manifest_model_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "model.onnx").write_bytes(b"not a real onnx model")
+    payload = {
+        "feature_pipeline": {
+            "feature_dim": FEATURE_DIM,
+            "feature_set": "v1",
+            "target_fps": FPS,
+            "sample_fps": FPS,
+            "imgsz": 960,
+        },
+        "inference": {
+            "input_name": "features",
+            "input_shape": [1, 100, FEATURE_DIM],
+            "seq_len_frames": 100,
+            "overlap_frames": 50,
+        },
+        "postprocess": {
+            "params": {
+                "high": 0.7,
+                "low": 0.45,
+                "sigma": 1.0,
+                "min_dur_sec": 1.0,
+            }
+        },
+    }
+    (path / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+    (path / "scaler.json").write_text(
+        json.dumps(
+            {
+                "feature_dim": FEATURE_DIM,
+                "mean": [0.0] * FEATURE_DIM,
+                "scale": [1.0] * FEATURE_DIM,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path

--- a/tests/test_cli_config_contract.py
+++ b/tests/test_cli_config_contract.py
@@ -60,6 +60,7 @@ def test_quick_run_uses_manifest_defaults_for_bundled_onnx(tmp_path, monkeypatch
     assert cfg.low == 0.45
     assert cfg.sigma == 1.0
     assert cfg.min_dur_sec == 1.0
+    assert cfg.imgsz == 960
 
 
 def test_explicit_config_can_override_manifest_defaults(tmp_path, monkeypatch):

--- a/tests/test_cli_config_contract.py
+++ b/tests/test_cli_config_contract.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from helpers.module_stubs import import_cli_main_with_stubs
+from helpers.runtime_fixtures import FPS, write_manifest_model_dir
+
+
+def _args(**overrides):
+    defaults = {
+        "config": None,
+        "video": None,
+        "output_dir": None,
+        "output_name": None,
+        "csv_output_dir": None,
+        "model_path": None,
+        "scaler_path": None,
+        "yolo_size": None,
+        "yolo_device": None,
+        "fps": None,
+        "seq_len": None,
+        "overlap": None,
+        "sigma": None,
+        "low": None,
+        "high": None,
+        "min_dur_sec": None,
+        "conf": None,
+        "start_time": None,
+        "duration": None,
+        "write_csv": None,
+        "segment_video": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _asset_args(tmp_path, **overrides):
+    model_dir = write_manifest_model_dir(tmp_path / "models" / "rallyclip_v0.3.1")
+    video_path = tmp_path / "match.mp4"
+    video_path.write_bytes(b"fake video")
+    return _args(
+        video=str(video_path),
+        model_path=str(model_dir / "model.onnx"),
+        scaler_path=str(model_dir / "scaler.json"),
+        **overrides,
+    )
+
+
+def test_quick_run_uses_manifest_defaults_for_bundled_onnx(tmp_path, monkeypatch):
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    cfg = cli_main.build_run_config(_asset_args(tmp_path))
+
+    assert cfg.fps == FPS
+    assert cfg.seq_len == 100
+    assert cfg.overlap == 50
+    assert cfg.high == 0.7
+    assert cfg.low == 0.45
+    assert cfg.sigma == 1.0
+    assert cfg.min_dur_sec == 1.0
+
+
+def test_explicit_config_can_override_manifest_defaults(tmp_path, monkeypatch):
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "custom.toml"
+    config_path.write_text(
+        """
+[run]
+fps = 15.0
+seq_len = 300
+overlap = 150
+high = 0.8
+sigma = 1.5
+min_dur_sec = 0.5
+""",
+        encoding="utf-8",
+    )
+
+    cfg = cli_main.build_run_config(_asset_args(tmp_path, config=str(config_path)))
+
+    assert cfg.fps == 15.0
+    assert cfg.seq_len == 300
+    assert cfg.overlap == 150
+    assert cfg.high == 0.8
+    assert cfg.sigma == 1.5
+    assert cfg.min_dur_sec == 0.5
+
+
+def test_incidental_repo_config_toml_does_not_break_quick_run(tmp_path, monkeypatch):
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.toml").write_text(
+        """
+[run]
+video_path = "stale.mp4"
+fps = 15.0
+seq_len = 300
+overlap = 150
+high = 0.8
+sigma = 1.5
+min_dur_sec = 0.5
+""",
+        encoding="utf-8",
+    )
+
+    cfg = cli_main.build_run_config(_asset_args(tmp_path))
+
+    assert cfg.fps == FPS
+    assert cfg.seq_len == 100
+    assert cfg.overlap == 50
+    assert cfg.high == 0.7
+    assert cfg.sigma == 1.0
+    assert cfg.min_dur_sec == 1.0
+
+
+def test_readme_documented_artifact_flags_are_supported_by_argparse(monkeypatch, tmp_path):
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rallyclip",
+            "--video",
+            str(tmp_path / "match.mp4"),
+            "--artifact-dir",
+            str(tmp_path / "models" / "rallyclip_v0.3.1"),
+            "--manifest-path",
+            str(tmp_path / "models" / "rallyclip_v0.3.1" / "manifest.json"),
+            "--no-segment-video",
+        ],
+    )
+    monkeypatch.setattr(cli_main, "build_run_config", lambda args: args)
+    monkeypatch.setattr(cli_main, "run_pipeline", lambda cfg: 0)
+
+    assert cli_main.main() == 0

--- a/tests/test_cli_pipeline_smoke.py
+++ b/tests/test_cli_pipeline_smoke.py
@@ -28,6 +28,7 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
         def extract_pose_data(self, **kwargs):
             calls.append("pose:extract")
             assert kwargs["target_fps"] == 5
+            assert kwargs["imgsz"] == 960
             assert kwargs["confidence_threshold"] == 0.25
             return str(tmp_path / "raw_pose.npz")
 
@@ -43,9 +44,12 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
             assert overwrite is True
             return True
 
+    feature_engineer_fps: list[float] = []
+
     class FakeFeatureEngineer:
-        def __init__(self):
+        def __init__(self, target_fps=None, **_kwargs):
             calls.append("features:init")
+            feature_engineer_fps.append(float(target_fps))
 
         def create_features_from_preprocessed(self, input_npz_path, output_file, overwrite):
             calls.append("features:run")
@@ -138,11 +142,13 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
         high=0.7,
         min_dur_sec=1.0,
         conf=0.25,
+        imgsz=960,
         start_time=0,
         duration=999999,
     )
 
     assert cli_main.run_pipeline(cfg) == 0
+    assert feature_engineer_fps == [5.0]
 
     assert calls == [
         "pose:init",

--- a/tests/test_cli_pipeline_smoke.py
+++ b/tests/test_cli_pipeline_smoke.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from helpers.module_stubs import import_cli_main_with_stubs
+from helpers.runtime_fixtures import FEATURE_DIM
+
+
+def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monkeypatch):
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    calls: list[str] = []
+    opened_npz = []
+    video_path = tmp_path / "match.mp4"
+    model_path = tmp_path / "model.onnx"
+    scaler_path = tmp_path / "scaler.json"
+    video_path.write_bytes(b"fake video")
+    model_path.write_bytes(b"fake onnx")
+    scaler_path.write_text("{}", encoding="utf-8")
+
+    class FakePoseExtractor:
+        def __init__(self, model_path, model_dir):
+            calls.append("pose:init")
+            assert model_path == "yolov8n-pose.pt"
+            assert Path(model_dir).name == "models"
+
+        def extract_pose_data(self, **kwargs):
+            calls.append("pose:extract")
+            assert kwargs["target_fps"] == 5
+            assert kwargs["confidence_threshold"] == 0.25
+            return str(tmp_path / "raw_pose.npz")
+
+    class FakePreprocessor:
+        def __init__(self, save_court_masks):
+            calls.append("preprocess:init")
+            assert save_court_masks is False
+
+        def preprocess_single_video(self, raw_npz, video, output_npz, overwrite):
+            calls.append("preprocess:run")
+            assert raw_npz.endswith("raw_pose.npz")
+            assert video == str(video_path)
+            assert overwrite is True
+            return True
+
+    class FakeFeatureEngineer:
+        def __init__(self):
+            calls.append("features:init")
+
+        def create_features_from_preprocessed(self, input_npz_path, output_file, overwrite):
+            calls.append("features:run")
+            assert input_npz_path.endswith("preprocessed.npz")
+            assert output_file.endswith("features.npz")
+            assert overwrite is True
+            return True
+
+    class TrackingNpz:
+        def __init__(self):
+            self.closed = False
+            self.features = np.ones((100, FEATURE_DIM), dtype=np.float32)
+
+        def __getitem__(self, key):
+            assert key == "features"
+            return self.features
+
+        def close(self):
+            self.closed = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+            return False
+
+    class FakeScaler:
+        def transform(self, features):
+            calls.append("scaler:transform")
+            assert features.shape == (100, FEATURE_DIM)
+            return features
+
+    def fake_np_load(path, *args, **kwargs):
+        calls.append("features:load")
+        assert str(path).endswith("features.npz")
+        npz = TrackingNpz()
+        opened_npz.append(npz)
+        return npz
+
+    def fake_onnx(model, features, sequence_length, overlap):
+        calls.append("inference:onnx")
+        assert model == str(model_path)
+        assert features.shape == (100, FEATURE_DIM)
+        assert sequence_length == 100
+        assert overlap == 50
+        probs = np.zeros(features.shape[0], dtype=np.float32)
+        probs[10:25] = 0.95
+        return probs
+
+    def fake_write_segments_csv(segments, output_csv_path, fps, overwrite):
+        calls.append("output:csv")
+        assert segments == [(10, 25)]
+        assert output_csv_path.endswith("_segments.csv")
+        assert fps == 5.0
+        assert overwrite is True
+
+    def fake_segment_video(input_video, intervals_sec, output_video):
+        calls.append("output:video")
+        assert input_video == str(video_path)
+        assert intervals_sec == [(2.0, 5.0)]
+        assert output_video.endswith("_segmented.mp4")
+
+    monkeypatch.setattr(cli_main, "PoseExtractor", FakePoseExtractor)
+    monkeypatch.setattr(cli_main, "DataPreprocessor", FakePreprocessor)
+    monkeypatch.setattr(cli_main, "FeatureEngineer", FakeFeatureEngineer)
+    monkeypatch.setattr(cli_main.np, "load", fake_np_load)
+    monkeypatch.setattr(cli_main, "load_scaler_asset", lambda _path: FakeScaler())
+    monkeypatch.setattr(cli_main, "run_windowed_inference_average_onnx", fake_onnx)
+    monkeypatch.setattr(cli_main, "gaussian_filter1d", lambda values, sigma: values)
+    monkeypatch.setattr(cli_main, "write_segments_csv", fake_write_segments_csv)
+    monkeypatch.setattr(cli_main, "segment_video", fake_segment_video)
+
+    cfg = cli_main.RunConfig(
+        video_path=video_path,
+        output_dir=tmp_path / "output_videos",
+        output_name=None,
+        csv_output_dir=tmp_path / "output_csvs",
+        write_csv=True,
+        segment_video=True,
+        yolo_weights="yolov8n-pose.pt",
+        yolo_device=None,
+        model_path=model_path,
+        scaler_path=scaler_path,
+        fps=5.0,
+        seq_len=100,
+        overlap=50,
+        sigma=1.0,
+        low=0.45,
+        high=0.7,
+        min_dur_sec=1.0,
+        conf=0.25,
+        start_time=0,
+        duration=999999,
+    )
+
+    assert cli_main.run_pipeline(cfg) == 0
+
+    assert calls == [
+        "pose:init",
+        "pose:extract",
+        "preprocess:init",
+        "preprocess:run",
+        "features:init",
+        "features:run",
+        "features:load",
+        "scaler:transform",
+        "inference:onnx",
+        "output:csv",
+        "output:video",
+    ]
+    assert opened_npz
+    assert all(npz.closed for npz in opened_npz)

--- a/tests/test_pose_extractor_contract.py
+++ b/tests/test_pose_extractor_contract.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import numpy as np
+
+from helpers.module_stubs import import_pose_extractor_with_stubs
+from helpers.runtime_fixtures import (
+    FRAME_HEIGHT,
+    FRAME_WIDTH,
+    RecordingFakeYoloModel,
+    fake_yolo_result,
+)
+
+
+class _FakeStream:
+    frames = 1
+
+
+class _FakeStreams:
+    video = [_FakeStream()]
+
+
+class _FakeContainer:
+    streams = _FakeStreams()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _extract_with_fake_model(tmp_path, monkeypatch, *, imgsz: int = 960, fail_on_batch: bool = False):
+    pose_module = import_pose_extractor_with_stubs(monkeypatch)
+    PoseExtractor = pose_module.PoseExtractor
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(pose_module.av, "open", lambda _path: _FakeContainer())
+
+    extractor = PoseExtractor.__new__(PoseExtractor)
+    extractor.model_path = "yolov8n-pose.pt"
+    extractor.model_dir = None
+    extractor.device = "cpu"
+    extractor.batch_size = 1
+    extractor.imgsz = imgsz
+    extractor.model = RecordingFakeYoloModel([fake_yolo_result(0)], fail_on_batch=fail_on_batch)
+    extractor.frame_iterator_pyav = lambda _path: iter(
+        [(np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8), 0.0)]
+    )
+
+    output_path = extractor.extract_pose_data(
+        video_path=str(tmp_path / "input.mp4"),
+        confidence_threshold=0.25,
+        start_time_seconds=0,
+        duration_seconds=1,
+        target_fps=5,
+    )
+    with np.load(output_path, allow_pickle=True) as data:
+        frames = data["frames"]
+    return extractor, frames[0]
+
+
+def test_pose_extractor_preserves_yolo_box_confidence(tmp_path, monkeypatch):
+    _extractor, frame = _extract_with_fake_model(tmp_path, monkeypatch)
+    expected = fake_yolo_result(0).boxes.conf.numpy()
+
+    np.testing.assert_allclose(frame["box_conf"], expected)
+
+
+def test_pose_extractor_passes_configured_imgsz_to_yolo_predict(tmp_path, monkeypatch):
+    extractor, _frame = _extract_with_fake_model(tmp_path, monkeypatch, imgsz=960)
+
+    assert extractor.model.predict_calls
+    assert extractor.model.predict_calls[-1]["imgsz"] == 960
+
+
+def test_pose_extractor_passes_configured_imgsz_to_fallback_predict(tmp_path, monkeypatch):
+    extractor, _frame = _extract_with_fake_model(tmp_path, monkeypatch, imgsz=960, fail_on_batch=True)
+
+    assert len(extractor.model.predict_calls) == 2
+    assert "batch" not in extractor.model.predict_calls[-1]
+    assert extractor.model.predict_calls[-1]["imgsz"] == 960
+
+
+def test_pose_extractor_keeps_original_frame_coordinate_scale(tmp_path, monkeypatch):
+    _extractor, frame = _extract_with_fake_model(tmp_path, monkeypatch, imgsz=960)
+
+    boxes = frame["boxes"]
+    keypoints = frame["keypoints"]
+
+    assert np.all((boxes[:, [0, 2]] >= 0) & (boxes[:, [0, 2]] <= FRAME_WIDTH))
+    assert np.all((boxes[:, [1, 3]] >= 0) & (boxes[:, [1, 3]] <= FRAME_HEIGHT))
+    assert np.all((keypoints[:, :, 0] >= 0) & (keypoints[:, :, 0] <= FRAME_WIDTH))
+    assert np.all((keypoints[:, :, 1] >= 0) & (keypoints[:, :, 1] <= FRAME_HEIGHT))
+
+
+def test_pose_extractor_preserves_confidence_ranges(tmp_path, monkeypatch):
+    _extractor, frame = _extract_with_fake_model(tmp_path, monkeypatch, imgsz=1920)
+
+    assert np.all((frame["box_conf"] >= 0.0) & (frame["box_conf"] <= 1.0))
+    assert np.all((frame["conf"] >= 0.0) & (frame["conf"] <= 1.0))

--- a/tests/test_runtime_feature_contract.py
+++ b/tests/test_runtime_feature_contract.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import numpy as np
+from pathlib import Path
+
+from features.feature_engineer import FeatureEngineer
+from training.features.v1 import FeatureSetV1
+
+from helpers.runtime_fixtures import (
+    ACCELERATION,
+    ACCELERATION_MAGNITUDE,
+    BOX_CONFIDENCE,
+    DT,
+    FEATURE_DIM,
+    FPS,
+    KEYPOINT_ACCELERATION,
+    KEYPOINT_ACCELERATION_MAGNITUDE,
+    PER_PLAYER_DIM,
+    SPEED,
+    VELOCITY,
+    absent_player,
+    expected_feature_sequence,
+    make_player,
+    make_runtime_assigned_players,
+    write_preprocessed_runtime_npz,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _offset(target: slice, amount: int) -> slice:
+    return slice(target.start + amount, target.stop + amount)
+
+
+def _create_features(tmp_path, assigned_frames: list[dict]) -> np.ndarray:
+    input_npz = write_preprocessed_runtime_npz(tmp_path / "preprocessed.npz", assigned_frames)
+    output_npz = tmp_path / "features.npz"
+    engineer = FeatureEngineer()
+    engineer.target_fps = FPS
+
+    assert engineer.create_features_from_preprocessed(str(input_npz), str(output_npz), overwrite=True)
+    with np.load(output_npz) as data:
+        return np.asarray(data["features"], dtype=np.float32)
+
+
+def test_runtime_feature_dim_matches_v1_and_bundled_scaler(tmp_path):
+    assigned_frames = [make_runtime_assigned_players(idx) for idx in range(3)]
+
+    features = _create_features(tmp_path, assigned_frames)
+
+    assert FeatureSetV1.feature_dim() == FEATURE_DIM
+    assert features.shape == (3, FeatureSetV1.feature_dim())
+
+    scaler_payload = json.loads((ROOT / "models" / "rallyclip_v0.3.1" / "scaler.json").read_text(encoding="utf-8"))
+    mean = np.asarray(scaler_payload["mean"], dtype=np.float32)
+    scale = np.asarray(scaler_payload["scale"], dtype=np.float32)
+    assert mean.shape == (FEATURE_DIM,)
+    assert scale.shape == (FEATURE_DIM,)
+    scaled = (features - mean) / np.maximum(scale, 1e-12)
+    assert scaled.shape == features.shape
+
+
+def test_runtime_full_vector_matches_independent_v1_layout_for_two_players(tmp_path):
+    assigned_frames = [make_runtime_assigned_players(idx) for idx in range(3)]
+    expected = expected_feature_sequence(
+        [(make_player("near", idx), make_player("far", idx)) for idx in range(3)],
+        dt=DT,
+    )
+
+    features = _create_features(tmp_path, assigned_frames)
+
+    np.testing.assert_allclose(features, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_runtime_motion_features_use_target_fps_dt(tmp_path):
+    assigned_frames = [make_runtime_assigned_players(idx) for idx in range(3)]
+    expected = expected_feature_sequence(
+        [(make_player("near", idx), make_player("far", idx)) for idx in range(3)],
+        dt=DT,
+    )
+
+    features = _create_features(tmp_path, assigned_frames)
+
+    np.testing.assert_allclose(features[1, VELOCITY], expected[1, VELOCITY], rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(features[2, ACCELERATION], expected[2, ACCELERATION], rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(
+        features[2, _offset(VELOCITY, PER_PLAYER_DIM)],
+        expected[2, _offset(VELOCITY, PER_PLAYER_DIM)],
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        features[2, _offset(ACCELERATION, PER_PLAYER_DIM)],
+        expected[2, _offset(ACCELERATION, PER_PLAYER_DIM)],
+        rtol=1e-6,
+        atol=1e-6,
+    )
+
+
+def test_runtime_keypoint_accelerations_are_computed(tmp_path):
+    assigned_frames = [make_runtime_assigned_players(idx) for idx in range(3)]
+    expected = expected_feature_sequence(
+        [(make_player("near", idx), make_player("far", idx)) for idx in range(3)],
+        dt=DT,
+    )
+
+    features = _create_features(tmp_path, assigned_frames)
+
+    assert np.any(expected[2, KEYPOINT_ACCELERATION] != 0.0)
+    np.testing.assert_allclose(
+        features[2, KEYPOINT_ACCELERATION],
+        expected[2, KEYPOINT_ACCELERATION],
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        features[2, KEYPOINT_ACCELERATION_MAGNITUDE],
+        expected[2, KEYPOINT_ACCELERATION_MAGNITUDE],
+        rtol=1e-6,
+        atol=1e-6,
+    )
+
+
+def test_runtime_one_player_absent_uses_v1_missing_player_sentinels(tmp_path):
+    assigned_frames = [make_runtime_assigned_players(idx, near=True, far=False) for idx in range(3)]
+    expected = expected_feature_sequence(
+        [(make_player("near", idx), absent_player()) for idx in range(3)],
+        dt=DT,
+    )
+
+    features = _create_features(tmp_path, assigned_frames)
+
+    np.testing.assert_allclose(features, expected, rtol=1e-6, atol=1e-6)
+    assert np.all(features[:, PER_PLAYER_DIM + 1 :] == -1.0)
+
+
+def test_runtime_reappearing_player_resets_motion_until_history_is_contiguous(tmp_path):
+    assigned_frames = [
+        make_runtime_assigned_players(0, near=True, far=True),
+        make_runtime_assigned_players(1, near=True, far=False),
+        make_runtime_assigned_players(2, near=True, far=True),
+    ]
+    expected = expected_feature_sequence(
+        [
+            (make_player("near", 0), make_player("far", 0)),
+            (make_player("near", 1), absent_player()),
+            (make_player("near", 2), make_player("far", 2)),
+        ],
+        dt=DT,
+    )
+
+    features = _create_features(tmp_path, assigned_frames)
+    far_frame_3 = features[2, PER_PLAYER_DIM:]
+
+    np.testing.assert_allclose(features, expected, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(far_frame_3[VELOCITY], np.zeros(2, dtype=np.float32))
+    np.testing.assert_allclose(far_frame_3[ACCELERATION], np.zeros(2, dtype=np.float32))
+    assert far_frame_3[SPEED] == -1.0
+    assert far_frame_3[ACCELERATION_MAGNITUDE] == -1.0
+    assert far_frame_3[BOX_CONFIDENCE] == make_player("far", 2)["box_conf"]

--- a/tests/test_runtime_preprocessing_contract.py
+++ b/tests/test_runtime_preprocessing_contract.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import numpy as np
+
+from helpers.module_stubs import import_data_preprocessor_with_stubs
+from helpers.runtime_fixtures import fake_yolo_result, write_raw_pose_npz
+
+
+def _disable_court_detection(monkeypatch, DataPreprocessor):
+    monkeypatch.setattr(DataPreprocessor, "generate_court_mask", lambda self, video_path: None)
+
+
+def test_runtime_preprocessor_propagates_box_conf_to_assigned_players(tmp_path, monkeypatch):
+    preprocessor_module = import_data_preprocessor_with_stubs(monkeypatch)
+    DataPreprocessor = preprocessor_module.DataPreprocessor
+    _disable_court_detection(monkeypatch, DataPreprocessor)
+    raw_path = write_raw_pose_npz(tmp_path / "raw_pose.npz", [fake_yolo_result(0)])
+    output_path = tmp_path / "preprocessed.npz"
+
+    preprocessor = DataPreprocessor(save_court_masks=False)
+    assert preprocessor.preprocess_single_video(str(raw_path), str(tmp_path / "input.mp4"), str(output_path), overwrite=True)
+
+    with np.load(output_path, allow_pickle=True) as data:
+        near = data["near_players"][0]
+        far = data["far_players"][0]
+
+    expected_box_conf = fake_yolo_result(0).boxes.conf.numpy()
+    assert near["box_conf"] == expected_box_conf[0]
+    assert far["box_conf"] == expected_box_conf[1]
+
+
+def test_runtime_preprocessor_assigns_near_and_far_deterministically(monkeypatch):
+    preprocessor_module = import_data_preprocessor_with_stubs(monkeypatch)
+    DataPreprocessor = preprocessor_module.DataPreprocessor
+    result = fake_yolo_result(0)
+    preprocessor = DataPreprocessor(save_court_masks=False)
+
+    assigned = preprocessor.assign_players(
+        {
+            "boxes": result.boxes.xyxy.numpy(),
+            "box_conf": result.boxes.conf.numpy(),
+            "keypoints": result.keypoints.xy.numpy(),
+            "conf": result.keypoints.conf.numpy(),
+            "annotation_status": 0,
+        }
+    )
+
+    assert assigned["near_player"]["box"][3] == result.boxes.xyxy.numpy()[0, 3]
+    assert assigned["far_player"]["box"][3] == result.boxes.xyxy.numpy()[1, 3]
+    assert assigned["near_player"]["box_conf"] == result.boxes.conf.numpy()[0]
+    assert assigned["far_player"]["box_conf"] == result.boxes.conf.numpy()[1]
+
+
+def test_runtime_preprocessor_closes_npz_file_handles(tmp_path, monkeypatch):
+    preprocessor_module = import_data_preprocessor_with_stubs(monkeypatch)
+    DataPreprocessor = preprocessor_module.DataPreprocessor
+    _disable_court_detection(monkeypatch, DataPreprocessor)
+    frames = [
+        {
+            "boxes": fake_yolo_result(0).boxes.xyxy.numpy(),
+            "box_conf": fake_yolo_result(0).boxes.conf.numpy(),
+            "keypoints": fake_yolo_result(0).keypoints.xy.numpy(),
+            "conf": fake_yolo_result(0).keypoints.conf.numpy(),
+            "annotation_status": 0,
+        }
+    ]
+    opened = []
+
+    class TrackingNpz:
+        def __init__(self):
+            self.closed = False
+
+        def __getitem__(self, key):
+            assert key == "frames"
+            return np.asarray(frames, dtype=object)
+
+        def close(self):
+            self.closed = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+            return False
+
+    def fake_load(*_args, **_kwargs):
+        npz = TrackingNpz()
+        opened.append(npz)
+        return npz
+
+    monkeypatch.setattr(preprocessor_module.np, "load", fake_load)
+
+    preprocessor = DataPreprocessor(save_court_masks=False)
+    assert preprocessor.preprocess_single_video(
+        str(tmp_path / "raw_pose.npz"),
+        str(tmp_path / "input.mp4"),
+        str(tmp_path / "preprocessed.npz"),
+        overwrite=True,
+    )
+
+    assert opened
+    assert all(npz.closed for npz in opened)


### PR DESCRIPTION
## Summary
- Align runtime feature extraction with the shipped `rallyclip_v0.3.1` 362-feature contract, including `box_conf`, `dt = 1/fps`, and keypoint accelerations.
- Make CLI/GUI quick-run defaults honor model manifest values while avoiding incidental stale `config.toml` overrides.
- Close temporary `.npz` handles and add runtime contract coverage for feature shape, motion scaling, pose extraction, config, and preprocessing.

## Test plan
- `python -m pytest` (50 passed, 2 sklearn metric warnings)

Made with [Cursor](https://cursor.com)