### PR TITLE
Manifest as single source of truth for inference config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,11 @@
 [run]
-# Required paths  - can also set with CLI args:
+# config.toml is your control panel: output/IO prefs + postprocess tuning knobs.
+# The MODEL CONTRACT (fps, seq_len, imgsz, conf, yolo_model, feature_set, screen size)
+# lives in the model's manifest.json and is the single source of truth for those.
+# Contract values set here are IGNORED (with a warning) — the manifest wins. To
+# intentionally diverge for an experiment, pass the matching CLI flag (e.g. --fps).
+
+# Required paths - can also set with CLI args:
 # video_path = "raw_videos/your_match.mp4"
 output_dir = "output_videos"
 
@@ -11,24 +17,29 @@ write_csv = true
 segment_video = true
 csv_output_dir = "output_csvs" # defaults to input video directory
 
-# YOLO pose model choice: nano | small | medium | large
-yolo_model = "small"
 # Optional device: cpu | cuda | mps (defaults to auto; set to "mps" for Apple Silicon)
 # yolo_device = "mps"
 
-# Optional overrides for assets:
-# model_path = "/path/to/lstm_300_v0.1.pth"
-# scaler_path = "/path/to/scaler_300_v0.1.joblib"
+# Optional overrides for assets (otherwise the bundled v0.3.1 artifact is used):
+# artifact_dir = "/path/to/model_dir"   # dir with model.onnx, scaler.json, manifest.json
+# model_path = "/path/to/model.onnx"
+# scaler_path = "/path/to/scaler.json"
+# manifest_path = "/path/to/manifest.json"
 
-# Pipeline parameters — v0.3.1 model defaults shown
-fps = 5.0
-seq_len = 100
+# Postprocess tuning (mutable — these operate on model output, not the model itself).
+# Defaults shown are the manifest's recommended params; tune freely.
 overlap = 50
 sigma = 1.0
 low = 0.45
 high = 0.7
 min_dur_sec = 1.0
-conf = 0.25
-imgsz = 960
+
+# Runtime window
 start_time = 0
 duration = 999999
+
+# --- Advanced: model-contract overrides (normally leave to the manifest) ---
+# These change the model's INPUTS and will skew inference if they don't match how the
+# model was trained. Use the CLI flags (--fps, --seq-len, --imgsz, --conf, --yolo-size)
+# for deliberate experiments; setting them here is ignored.
+# v0.3.1 contract, for reference: fps=5.0 seq_len=100 imgsz=960 conf=0.25 yolo=nano

--- a/docs/runtime-config-refactor-plan.md
+++ b/docs/runtime-config-refactor-plan.md
@@ -1,0 +1,252 @@
+# Runtime Config Refactor + Backwards Compat — Plan
+
+**Status:** Planning (not yet implemented)
+**Branch:** `fix/runtime-pipeline-drift` (refactor will likely get its own branch off this)
+**Owner:** ismael
+**Last updated:** 2026-06-03
+
+---
+
+## 1. Problem
+
+The inference pipeline does not have a single source of truth for its parameters.
+The same concepts have different values in different places, and the divergent values
+are the **old v0.1 model's contract** masquerading as defaults.
+
+Three sources of truth today:
+- `models/rallyclip_v0.3.1/manifest.json` — correct v0.3.1 contract
+- `config.toml` — correct v0.3.1 values
+- Hardcoded literals in `RunConfig` + `build_run_config` — the **stale v0.1 contract**
+  (`seq_len=300`, `overlap=150`, `sigma=1.5`, `high=0.8`, `min_dur_sec=0.5`, `fps=15`)
+
+They agree only on the bundled ONNX happy path. The moment the manifest is missing or
+`RunConfig` is constructed directly, the phantom v0.1 contract silently takes over.
+
+### Why this is dangerous
+Inference is silent. Extract at 15fps instead of 5, build 360 features instead of 362,
+or window at 300 instead of 100, and the model emits wrong segments with no error.
+
+### Codex audit findings (2026-06-03, verified)
+Confirmed reachable issues:
+- **P1** `RunConfig` dataclass defaults + `build_run_config` fallback literals encode v0.1
+  ([src/cli/main.py:54-60](../src/cli/main.py#L54), [:240-246](../src/cli/main.py#L240)).
+  Reachable via direct `RunConfig(...)` construction, or `--video` + a manifest-less model.
+- **P1** `screen_width=1280`/`screen_height=720` hardcoded, affect feature values, not in any
+  manifest/config ([src/features/feature_engineer.py:9](../src/features/feature_engineer.py#L9),
+  [src/preprocessing/data_preprocessor.py:9](../src/preprocessing/data_preprocessor.py#L9)).
+- **P2 behavioral bug** `write_csv` falls back to `False` when `--video` skips config.toml,
+  even though config says `true` ([src/cli/main.py:193](../src/cli/main.py#L193)). `--video x.mp4`
+  silently writes no CSV. Blocks the validation harness.
+- **P2** pose extractor `imgsz=1920`/`target_fps=15` standalone defaults; court detector
+  `conf=0.5` + hardcoded `models/yolov8s-pose.pt`; legacy `lstm_300`/`seq_len300` asset fallbacks.
+- **Root cause** `--video` skips config.toml ([src/cli/main.py:169](../src/cli/main.py#L169)),
+  which makes every fallback literal reachable in a normal run.
+- **Downgraded** `input_size=360` ([src/infer/model.py:6](../src/infer/model.py#L6)) is
+  self-correcting (overridden by checkpoint weight shape) and ONNX never hits it.
+
+`conf` is a latent contract gap: manifest has `conf: null`, runtime uses `0.25`. Pose conf
+filters detections that become features, so it belongs in the contract but was never pinned
+at export. **Needs verification: what conf did training run at?**
+
+---
+
+## 2. Goals / Principles
+
+1. **One guiding config for inference.** Every pipeline parameter resolves from manifest or
+   config. No phantom literal defaults.
+2. **Crash on missing, don't guess.** If a required contract/postprocess value is not present
+   in manifest or config, fail loudly with a clear message. (Exempt: pure runtime/IO prefs.)
+3. **Immutable vs mutable separation.** The model's identity is immutable and lives in the
+   manifest. Tuning knobs are mutable and live in config.
+4. **Models are self-describing.** Each model ships its own manifest; swapping models = swapping
+   manifests. Backwards compat rides the same rails, no special-case legacy code.
+
+---
+
+## 3. Field Taxonomy
+
+### Bucket 1 — Immutable (model identity). Source: **manifest only.** Crash if absent.
+Changing these changes the inputs the model learned a function of → degraded/garbage output.
+
+| Field | Notes |
+|---|---|
+| `feature_dim`, `feature_set` | Input tensor width. Already enforced via `FeatureSetV1`. |
+| `seq_len` | ONNX input shape `[1, seq_len, feature_dim]`. Model rejects wrong value. |
+| `target_fps` | Velocity/accel features scale by `dt`. Temporal dynamics assume this rate. |
+| `imgsz` | YOLO resolution → keypoint coords → feature values. |
+| `screen_width`, `screen_height` | Coordinate normalization. **Currently hardcoded, must move into manifest.** |
+| `num_keypoints` (17) | Structural. |
+| `conf` (pose) | Filters detections that become features. **Currently unpinned (manifest null) — verify.** |
+
+CLI/config override of immutable fields: **allowed but warns loudly** ("overriding a
+model-contract value, expect degraded perf"). Decision pending — see §7.
+
+### Bucket 2 — Mutable (postprocessing). Source: **config override → manifest.postprocess → crash.**
+Operate on model *output* probabilities. Tune freely; the model is untouched.
+
+| Field | Tunes |
+|---|---|
+| `low`, `high` | Hysteresis sensitivity (precision/recall). |
+| `sigma` | Probability-curve smoothing. |
+| `min_dur_sec` | Minimum segment duration. |
+| `threshold` | Base decision threshold. |
+| `overlap` | Window stride/averaging (throughput vs smoothness). **Mutable** — model never sees it. |
+
+### Bucket 3 — Runtime / IO. Source: **config → sane default OK.** Not a model lever.
+`output_dir`, `output_name`, `csv_output_dir`, `write_csv`, `segment_video`, `yolo_device`,
+`start_time`, `duration`. Defaults are fine here (crashing because `output_dir` is unset is just annoying).
+
+---
+
+## 4. Architecture
+
+- **`manifest.json` = the model's birth certificate.** Immutable contract + training provenance
+  (sha256, git commit, epoch) + recommended postprocess params. Never hand-edited. Missing → crash.
+- **`config.toml` = the operator's control panel.** Mutable postprocess knobs + runtime IO.
+  Ships with the discovered best-outcome defaults. Edit here to tune; never touch the model card.
+- **`FeatureRegistry`** ([src/training/features/registry.py](../src/training/features/registry.py))
+  routes `manifest.feature_set` → builder class. Currently registers only `"v1"`.
+
+UX:
+- Different **tuning** → edit `config.toml`.
+- Different **model** → bring your own `model.onnx` + `manifest.json` (regenerated by training export).
+
+---
+
+## 5. Phase 1 — Config Refactor (DO FIRST)
+
+Make the manifest the single source for immutable fields, config for mutable, no literals.
+
+**Tasks:**
+1. Remove stale literal defaults from `RunConfig` dataclass ([src/cli/main.py:54-60](../src/cli/main.py#L54)).
+   Contract fields become required / sentinel, not v0.1 numbers.
+2. Rewrite `build_run_config` resolution ([src/cli/main.py:229-251](../src/cli/main.py#L229)):
+   - Immutable: manifest (or explicit override w/ warning). Missing → `SystemExit` with guidance.
+   - Mutable: config → `manifest.postprocess` → crash. No literals.
+   - IO: config → sane default.
+3. Extend `_manifest_defaults_for_model` to also read `feature_set`, `screen_width`,
+   `screen_height`, `conf`, `threshold` (add these to the manifest schema first).
+4. Add `screen_width`/`screen_height` to the manifest and plumb them through
+   `FeatureEngineer` / `DataPreprocessor` (remove the hardcoded 1280/720).
+5. Fix the `write_csv` behavioral bug — `--video` must not silently drop config's `write_csv`.
+   Likely: load config.toml even with `--video` for IO/mutable fields, OR make the IO defaults
+   match config. (Revisit the "`--video` skips config.toml" decision — it's the root cause.)
+6. Drop legacy asset fallbacks (`lstm_300_v0.1.pth`, `seq_len300`, `scaler_300`) from
+   `_resolve_asset` relatives — legacy becomes a normal manifest-driven artifact (Phase 3).
+7. Tests: manifest-required crash path, mutable override path, no-literal assertion,
+   `write_csv` honored with `--video`, screen_w/h sourced from manifest.
+
+**Out of scope for Phase 1:** GUI (deprecated + broken static path; see §8), `FeatureSetV0`.
+
+---
+
+## 6. Phase 2 — Validation Harness + v0.3.1 Baseline
+
+Confirm the shipping model's perf isn't degraded, and build the tool Phase 3 needs.
+
+**Data (in training repo `/Users/ismaelrobles-razzaq/cs_projects/RallyClip`):**
+- Raw videos: `data/raw_videos/` (11 val-set base files)
+- Ground truth: `data/annotations/*.json` (one per video)
+
+**Tasks:**
+1. Glue script: run CLI on a raw video → segment CSV → compare to `.json` GT →
+   feed through [src/training/metrics/segment.py](../src/training/metrics/segment.py).
+2. Report the 4 categories: false positive (`false_detected`), false negative (missed GT),
+   good (sufficient `gt_coverage`), detected-but-insufficient-overlap.
+3. Run across the val set, compare to manifest `metrics` (segment_f1 0.67, etc.).
+
+This harness is reused as the v0 correctness check (Phase 3) and the Docker acceptance test.
+
+---
+
+## 7. v0 Backwards Compat (OPTIONAL — not committed, fully spec'd)
+
+**Priority: low / nice-to-have.** Not required for shipping. The container only bundles
+v0.3.1; the legacy model lives in the training repo. Phase 1's design *reserves the slot*
+(registry + `feature_set` routing), so this can be picked up later with zero rework if ever
+wanted. The spec below is preserved so the archaeology isn't lost — but don't treat it as
+planned work.
+
+If ever done: make the legacy v0.1 model runnable through the same manifest-driven rails.
+Gated on the Phase 2 harness (can't ship a resurrected builder without proving byte-correctness
+on a labeled video).
+
+### Archaeology (done 2026-06-03, training repo git history)
+- **Legacy is already an ONNX artifact:** `models/rallyclip_v0.1.0_legacy/` has
+  `model.onnx` + `scaler.json` + `manifest.json`. Use the ONNX; retire the `.pth`.
+- **Legacy contract** (from its manifest): `feature_dim=360`, `target_fps=15`, `conf=0.25`,
+  `imgsz=null`, `input_shape=[1,300,360]`, `seq_len=300`, `overlap=150`,
+  postprocess `high=0.8 low=0.45 min_dur=0.5 sigma=1.5`.
+- **360→362 cutover commit: `6bc24e6` "finalize artifact cli runtime" (2026-03-30)** —
+  appended `+ 1` / `box_conf` to the per-player formula.
+- **Canonical v0 source: `12e5c9d:src/features/feature_engineer.py`** — last 360 version,
+  byte-identical math to initial commit `600b388` (only diff is print→logging).
+  `features_per_player = 1+4+2+2+2+1+1 + 17*3 + 17*2 + 17*2 + 17 + 17 + 14 = 180`, ×2 = **360**.
+
+### Two landmines
+1. **`feature_set` name is overloaded.** The legacy manifest says `feature_set: "v1"` but is
+   360-dim; current `"v1"` is 362. **Do not route on the name alone.** Fix the legacy manifest
+   to `feature_set: "v0"`, and/or also validate against `feature_dim`.
+2. **Motion scaling differs (train/serve skew trap).** The v0 builder uses `dt = 1.0` (raw
+   per-frame deltas). v1 uses `dt = 1.0 / target_fps` = 0.2 at 5fps. Running v0 through v1's
+   scaling makes every velocity/accel **5× too large** → garbage. `FeatureSetV0` must bake in
+   `dt=1.0` and ignore `target_fps`. **Port verbatim; do not derive v0 from v1.**
+   - (Layout note: v1 = v0 with box_conf appended per player block, so v0 = v1 minus indices
+     180 and 361 — not a simple tail-trim. Another reason to port the original code.)
+
+### Tasks
+1. Port `12e5c9d`'s `create_feature_vector` + `_calculate_velocity/_acceleration/_keypoint_velocity`
+   (dt=1.0) + centroid/limb/normalization helpers into a `FeatureSetV0` class. `feature_vector_size=288`
+   default is dead code — ignore it.
+2. Register `"v0"` in `FeatureRegistry`.
+3. Fix `models/rallyclip_v0.1.0_legacy/manifest.json` `feature_set` → `"v0"`.
+4. Validate the legacy ONNX end-to-end on a labeled video using the Phase 2 harness.
+
+---
+
+## 8. Out of Scope
+
+- **GUI** ([src/gui/app.py](../src/gui/app.py)) — deprecated (noted in README) and currently
+  broken: `_find_static_dir()` resolves to a nonexistent `apps/gui/frontend` (actual bundle is
+  `gui/frontend`), so it launches but serves no UI. Also builds config independently of
+  `build_run_config` and never reads config.toml/manifest. Leave alone; revisit if revived.
+- **Docker** — separate effort, comes after validation. The Phase 2 harness becomes its
+  acceptance test (run same video in container, compare the 4 metrics).
+
+---
+
+## 9. Open Questions
+
+1. **`conf` — RESOLVED, no skew.** Training built features at `conf=0.25` (on-disk pose data is
+   namespaced `conf=0p25`; training scripts default 0.25), runtime uses 0.25. They match. The only
+   gap is the manifest records `conf: null` — pin `conf: 0.25` in the manifest as immutable. Low priority.
+2. **`yolo_model` — CONFIRMED SKEW: trained on NANO, CLI defaults to small (high priority).**
+   Model was trained on **nano** (confirmed by user + on-disk evidence), but config.toml ships
+   `yolo_model = "small"` ([../config.toml#L15](../config.toml#L15)) and manifest `yolo_model: null`.
+   Evidence:
+   - Run `prod_yolon960_fps5_seq20` = fps 5 / imgsz 960. **nano** has `imgsz=960/fps=5.0` with
+     **22 files** (= manifest `video_count: 22`); **small** has *zero* fps=5 features (only fps=15.0).
+   - Run name literally `yolo**n**960`.
+   The shipping CLI default (`small`) runs a different pose model than training → **live pose
+   train/serve skew** (small vs nano produce different keypoints, feeding the features).
+   **Action:** set config.toml default `yolo_model = "nano"` and pin manifest
+   `yolo_model: "yolov8n-pose"`. (Note: run `config.json` does not record the yolo model — that's
+   why it was ambiguous; pinning it in the manifest fixes that permanently.)
+3. **`--video` + config.toml — RESOLVED in principle.** The coarse "skip all of config.toml when
+   `--video`" hack ([src/cli/main.py:169](../src/cli/main.py#L169)) becomes unnecessary once Phase 1
+   does bucket-based resolution: manifest wins for immutable (so stale config can't override the
+   contract), config always provides mutable + IO. **Delete the skip**; this also fixes the `write_csv`
+   bug for free.
+4. **Immutable override policy** — warn-and-allow vs hard-forbid CLI/config override of Bucket 1
+   fields. Leaning warn-and-allow (you're the only one who'd experiment).
+
+---
+
+## 10. Sequencing Summary
+
+1. Phase 1: config refactor (this is "codex fixes" + single-source design).
+2. Phase 2: validation harness + v0.3.1 baseline.
+3. (Separate) Docker, with Phase 2 harness as acceptance test.
+
+Optional / not committed: v0 backwards compat (§7) — pick up only if the legacy model
+ever needs to run through this CLI.

--- a/models/rallyclip_v0.3.1/manifest.json
+++ b/models/rallyclip_v0.3.1/manifest.json
@@ -77,14 +77,17 @@
     ]
   },
   "feature_pipeline": {
-    "conf": null,
+    "conf": 0.25,
     "feature_dim": 362,
     "feature_set": "v1",
     "imgsz": 960.0,
+    "num_keypoints": 17,
     "sample_fps": 5.0,
     "sampling_mode": null,
+    "screen_height": 720,
+    "screen_width": 1280,
     "target_fps": 5.0,
-    "yolo_model": null
+    "yolo_model": "yolov8n-pose.pt"
   },
   "files": {
     "manifest_file": "manifest.json",

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -372,6 +372,7 @@ def run_pipeline(cfg: RunConfig) -> int:
             screen_height=int(cfg.screen_height),
             save_court_masks=False,
             yolo_model_path=cfg.yolo_weights,
+            conf=float(cfg.conf),
         )
         pre.preprocess_single_video(raw_npz, str(cfg.video_path), str(preprocessed_npz), overwrite=True)
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -371,6 +371,7 @@ def run_pipeline(cfg: RunConfig) -> int:
             screen_width=int(cfg.screen_width),
             screen_height=int(cfg.screen_height),
             save_court_masks=False,
+            yolo_model_path=cfg.yolo_weights,
         )
         pre.preprocess_single_video(raw_npz, str(cfg.video_path), str(preprocessed_npz), overwrite=True)
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -156,7 +156,8 @@ def _manifest_values(model_path: Path, manifest_path: Optional[Path] = None) -> 
         return {}
     try:
         payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except Exception:
+    except Exception as e:
+        logging.warning("Found manifest at %s but could not parse it (%s); ignoring it.", manifest_path, e)
         return {}
 
     inference = payload.get("inference", {}) or {}
@@ -203,8 +204,13 @@ def _num_differs(a: Any, b: Any) -> bool:
         return str(a) != str(b)
 
 
-def _resolve_contract(name: str, cli_val: Any, manifest_val: Any) -> Any:
-    """Immutable field: manifest is authoritative; explicit CLI override warns; crash if unresolved."""
+def _resolve_contract(name: str, cli_val: Any, manifest_val: Any, cli_flag: Optional[str] = None) -> Any:
+    """Immutable field: manifest is authoritative; explicit CLI override warns; crash if unresolved.
+
+    cli_flag is the real argparse flag that overrides this field, if one exists. Some contract
+    fields (feature_set, screen_width, screen_height) are manifest-only and have no CLI flag, so
+    the error message must not advertise one.
+    """
     if cli_val is not None:
         if manifest_val is not None and _num_differs(cli_val, manifest_val):
             logging.warning(
@@ -214,10 +220,11 @@ def _resolve_contract(name: str, cli_val: Any, manifest_val: Any) -> Any:
         return cli_val
     if manifest_val is not None:
         return manifest_val
+    override = f", or pass {cli_flag} to override" if cli_flag else ""
     raise SystemExit(
         f"Required contract field '{name}' is missing from the model manifest and was not passed "
         f"on the CLI. Use a model artifact with a complete manifest.json "
-        f"(--artifact-dir / --manifest-path), or pass --{name.replace('_', '-')} to override."
+        f"(--artifact-dir / --manifest-path){override}."
     )
 
 
@@ -294,16 +301,16 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
     manifest = _manifest_values(model_path, manifest_path)
 
     # Immutable contract: manifest is authoritative; only an explicit CLI flag overrides (warns).
-    fps = float(_resolve_contract("fps", arg("fps"), manifest.get("fps")))
-    seq_len = int(_resolve_contract("seq_len", arg("seq_len"), manifest.get("seq_len")))
-    imgsz = int(_resolve_contract("imgsz", arg("imgsz"), manifest.get("imgsz")))
-    conf = float(_resolve_contract("conf", arg("conf"), manifest.get("conf")))
+    fps = float(_resolve_contract("fps", arg("fps"), manifest.get("fps"), "--fps"))
+    seq_len = int(_resolve_contract("seq_len", arg("seq_len"), manifest.get("seq_len"), "--seq-len"))
+    imgsz = int(_resolve_contract("imgsz", arg("imgsz"), manifest.get("imgsz"), "--imgsz"))
+    conf = float(_resolve_contract("conf", arg("conf"), manifest.get("conf"), "--conf"))
     feature_set = str(_resolve_contract("feature_set", None, manifest.get("feature_set")))
     screen_width = int(_resolve_contract("screen_width", None, manifest.get("screen_width")))
     screen_height = int(_resolve_contract("screen_height", None, manifest.get("screen_height")))
 
     cli_yolo = YOLO_SIZE_MAP.get(arg("yolo_size"), arg("yolo_size")) if arg("yolo_size") else None
-    yolo_weights = str(_resolve_contract("yolo_model", cli_yolo, manifest.get("yolo_model")))
+    yolo_weights = str(_resolve_contract("yolo_model", cli_yolo, manifest.get("yolo_model"), "--yolo-size"))
 
     # Mutable postprocess: CLI -> config -> manifest -> crash.
     overlap = int(_resolve_mutable("overlap", arg("overlap"), cfg("overlap"), manifest.get("overlap")))
@@ -345,6 +352,13 @@ def run_pipeline(cfg: RunConfig) -> int:
         print(f"Error: video file not found at '{cfg.video_path}'")
         return 1
 
+    # Fail fast, before the expensive pose/preprocess passes: only feature_set 'v1' is implemented.
+    if cfg.feature_set != "v1":
+        raise SystemExit(
+            f"This model declares feature_set='{cfg.feature_set}', but only 'v1' is implemented "
+            f"in the runtime. See docs/runtime-config-refactor-plan.md (§7, v0 backwards compat)."
+        )
+
     cfg.output_dir.mkdir(parents=True, exist_ok=True)
     base_name = cfg.output_name or cfg.video_path.stem
 
@@ -376,11 +390,6 @@ def run_pipeline(cfg: RunConfig) -> int:
         )
         pre.preprocess_single_video(raw_npz, str(cfg.video_path), str(preprocessed_npz), overwrite=True)
 
-        if cfg.feature_set != "v1":
-            raise SystemExit(
-                f"This model declares feature_set='{cfg.feature_set}', but only 'v1' is implemented "
-                f"in the runtime. See docs/runtime-config-refactor-plan.md (§7, v0 backwards compat)."
-            )
         fe = FeatureEngineer(
             screen_width=int(cfg.screen_width),
             screen_height=int(cfg.screen_height),

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 import tempfile
@@ -41,6 +42,7 @@ YOLO_SIZE_MAP = {
 
 @dataclass
 class RunConfig:
+    # Paths / IO targets
     video_path: Path
     output_dir: Path
     output_name: Optional[str]
@@ -51,15 +53,21 @@ class RunConfig:
     yolo_device: Optional[str]
     model_path: Path
     scaler_path: Path
-    fps: float = 15.0
-    seq_len: int = 300
-    overlap: int = 150
-    sigma: float = 1.5
-    low: float = 0.45
-    high: float = 0.8
-    min_dur_sec: float = 0.5
-    conf: float = 0.25
-    imgsz: int = 960
+    # Immutable contract (resolved from manifest; no phantom defaults)
+    fps: float
+    seq_len: int
+    imgsz: int
+    conf: float
+    feature_set: str
+    screen_width: int
+    screen_height: int
+    # Mutable postprocess (config -> manifest)
+    overlap: int
+    sigma: float
+    low: float
+    high: float
+    min_dur_sec: float
+    # Runtime IO prefs (safe defaults are fine here)
     start_time: int = 0
     duration: int = 999999
 
@@ -129,9 +137,20 @@ def _pick_bool(arg_val: Optional[bool], cfg_val: Optional[Any], default: bool) -
     return default
 
 
-def _manifest_defaults_for_model(model_path: Path, manifest_path: Optional[Path] = None) -> Dict[str, Any]:
-    if manifest_path is None and model_path.suffix.lower() != ".onnx":
-        return {}
+# Immutable contract fields: the model's identity. Sourced from the manifest only;
+# config.toml has no authority over these. An explicit CLI flag may override (with a
+# warning), since that is a deliberate experiment. See docs/runtime-config-refactor-plan.md.
+_CONTRACT_FIELDS = (
+    "fps", "seq_len", "imgsz", "conf", "feature_set", "screen_width", "screen_height", "yolo_model",
+)
+
+
+def _manifest_values(model_path: Path, manifest_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Read the model's manifest into a flat dict of contract + postprocess values.
+
+    Returns {} if no manifest can be found/parsed; callers crash on missing required
+    fields rather than substituting phantom defaults.
+    """
     manifest_path = manifest_path or (model_path.parent / "manifest.json")
     if not manifest_path.exists():
         return {}
@@ -139,39 +158,100 @@ def _manifest_defaults_for_model(model_path: Path, manifest_path: Optional[Path]
         payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     except Exception:
         return {}
-    defaults: Dict[str, Any] = {}
+
     inference = payload.get("inference", {}) or {}
     postprocess = (payload.get("postprocess", {}) or {}).get("params", {}) or {}
     feature_pipeline = payload.get("feature_pipeline", {}) or {}
-    if "seq_len_frames" in inference:
-        defaults["seq_len"] = int(inference["seq_len_frames"])
-    if "overlap_frames" in inference:
-        defaults["overlap"] = int(inference["overlap_frames"])
-    if "target_fps" in feature_pipeline:
-        defaults["fps"] = float(feature_pipeline["target_fps"])
-    if "imgsz" in feature_pipeline:
-        defaults["imgsz"] = int(float(feature_pipeline["imgsz"]))
-    if "sigma" in postprocess:
-        defaults["sigma"] = float(postprocess["sigma"])
-    if "low" in postprocess:
-        defaults["low"] = float(postprocess["low"])
-    if "high" in postprocess:
-        defaults["high"] = float(postprocess["high"])
-    if "min_dur_sec" in postprocess:
-        defaults["min_dur_sec"] = float(postprocess["min_dur_sec"])
-    return defaults
+    values: Dict[str, Any] = {}
+
+    # Contract (immutable)
+    if feature_pipeline.get("target_fps") is not None:
+        values["fps"] = float(feature_pipeline["target_fps"])
+    if inference.get("seq_len_frames") is not None:
+        values["seq_len"] = int(inference["seq_len_frames"])
+    if feature_pipeline.get("imgsz") is not None:
+        values["imgsz"] = int(float(feature_pipeline["imgsz"]))
+    if feature_pipeline.get("conf") is not None:
+        values["conf"] = float(feature_pipeline["conf"])
+    if feature_pipeline.get("feature_set") is not None:
+        values["feature_set"] = str(feature_pipeline["feature_set"])
+    if feature_pipeline.get("screen_width") is not None:
+        values["screen_width"] = int(feature_pipeline["screen_width"])
+    if feature_pipeline.get("screen_height") is not None:
+        values["screen_height"] = int(feature_pipeline["screen_height"])
+    if feature_pipeline.get("yolo_model") is not None:
+        values["yolo_model"] = str(feature_pipeline["yolo_model"])
+
+    # Postprocess (mutable)
+    if inference.get("overlap_frames") is not None:
+        values["overlap"] = int(inference["overlap_frames"])
+    if postprocess.get("sigma") is not None:
+        values["sigma"] = float(postprocess["sigma"])
+    if postprocess.get("low") is not None:
+        values["low"] = float(postprocess["low"])
+    if postprocess.get("high") is not None:
+        values["high"] = float(postprocess["high"])
+    if postprocess.get("min_dur_sec") is not None:
+        values["min_dur_sec"] = float(postprocess["min_dur_sec"])
+    return values
+
+
+def _num_differs(a: Any, b: Any) -> bool:
+    try:
+        return abs(float(a) - float(b)) > 1e-9
+    except (TypeError, ValueError):
+        return str(a) != str(b)
+
+
+def _resolve_contract(name: str, cli_val: Any, manifest_val: Any) -> Any:
+    """Immutable field: manifest is authoritative; explicit CLI override warns; crash if unresolved."""
+    if cli_val is not None:
+        if manifest_val is not None and _num_differs(cli_val, manifest_val):
+            logging.warning(
+                "Overriding model-contract field '%s'=%r (manifest=%r). This changes the model's "
+                "inputs; expect degraded inference unless intentional.", name, cli_val, manifest_val,
+            )
+        return cli_val
+    if manifest_val is not None:
+        return manifest_val
+    raise SystemExit(
+        f"Required contract field '{name}' is missing from the model manifest and was not passed "
+        f"on the CLI. Use a model artifact with a complete manifest.json "
+        f"(--artifact-dir / --manifest-path), or pass --{name.replace('_', '-')} to override."
+    )
+
+
+def _resolve_mutable(name: str, cli_val: Any, cfg_val: Any, manifest_val: Any) -> Any:
+    """Mutable postprocess field: CLI -> config -> manifest -> crash."""
+    val = cli_val if cli_val is not None else (cfg_val if cfg_val is not None else manifest_val)
+    if val is None:
+        raise SystemExit(
+            f"Postprocess parameter '{name}' is missing from both config and the model manifest. "
+            f"Set it in config.toml or use a manifest with a postprocess section."
+        )
+    return val
 
 
 def build_run_config(args: argparse.Namespace) -> RunConfig:
     def arg(key: str, default=None):
         return getattr(args, key, default)
 
-    cfg_path = arg("config") or (None if arg("video") else ("config.toml" if Path("config.toml").exists() else None))
+    # config.toml is always loaded (explicit --config, else ./config.toml). It owns mutable
+    # postprocess + IO only; it has no authority over immutable contract fields.
+    cfg_path = arg("config") or ("config.toml" if Path("config.toml").exists() else None)
     cfg_dict = _load_config_dict(cfg_path) if cfg_path else {}
     cfg_section = cfg_dict.get("run", cfg_dict) if isinstance(cfg_dict, dict) else {}
 
     def cfg(key: str, default=None):
         return cfg_section.get(key, default) if isinstance(cfg_section, dict) else default
+
+    # A leftover/legacy config.toml must not silently corrupt the contract: warn + ignore.
+    for field in _CONTRACT_FIELDS:
+        if cfg(field) is not None:
+            logging.warning(
+                "config.toml sets contract field '%s'; ignoring it (the model manifest is "
+                "authoritative). Pass --%s to override intentionally.", field, field.replace("_", "-"),
+            )
 
     video_path = arg("video") or cfg("video_path")
     output_dir = arg("output_dir") or cfg("output_dir") or str(Path.cwd() / "output_videos")
@@ -180,19 +260,14 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
 
     output_name = arg("output_name") or cfg("output_name")
     csv_output_dir_raw = arg("csv_output_dir") or cfg("csv_output_dir")
-
-    yolo_choice = arg("yolo_size") or cfg("yolo_model")
-    if yolo_choice and yolo_choice in YOLO_SIZE_MAP:
-        yolo_weights = YOLO_SIZE_MAP[yolo_choice]
-    elif yolo_choice:
-        yolo_weights = str(yolo_choice)
-    else:
-        yolo_weights = YOLO_SIZE_MAP["small"]
     yolo_device = arg("yolo_device") or cfg("yolo_device")
 
+    # IO prefs: CLI -> config -> sane default.
     write_csv = _pick_bool(arg("write_csv"), cfg("write_csv"), False)
     segment_video_flag = _pick_bool(arg("segment_video"), cfg("segment_video"), True)
 
+    # Asset resolution. Legacy .pth/.joblib fallbacks removed: every model is a
+    # manifest-driven artifact (model.onnx + scaler.json + manifest.json).
     artifact_dir_raw = arg("artifact_dir") or cfg("artifact_dir")
     artifact_dir = Path(artifact_dir_raw).expanduser().resolve() if artifact_dir_raw else None
     model_path_raw = arg("model_path") or cfg("model_path")
@@ -206,25 +281,36 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
     model_path = _resolve_asset(
         model_path_raw,
         env_var="RALLYCLIP_MODEL_PATH",
-        relatives=[
-            "models/rallyclip_v0.3.1/model.onnx",
-            "models/lstm_300_v0.1.pth",
-            "checkpoints/seq_len300/best_model.pth",
-        ],
-        description="RallyClip model artifact (ONNX or PyTorch checkpoint)",
+        relatives=["models/rallyclip_v0.3.1/model.onnx"],
+        description="RallyClip model artifact (ONNX)",
     )
     scaler_path = _resolve_asset(
         scaler_path_raw,
         env_var="RALLYCLIP_SCALER_PATH",
-        relatives=[
-            "models/rallyclip_v0.3.1/scaler.json",
-            "models/scaler_300_v0.1.joblib",
-            "data/seq_len_300/scaler.joblib",
-        ],
-        description="RallyClip scaler artifact (JSON or joblib)",
+        relatives=["models/rallyclip_v0.3.1/scaler.json"],
+        description="RallyClip scaler artifact (JSON)",
     )
     manifest_path = Path(manifest_path_raw).expanduser().resolve() if manifest_path_raw else None
-    manifest_defaults = _manifest_defaults_for_model(model_path, manifest_path)
+    manifest = _manifest_values(model_path, manifest_path)
+
+    # Immutable contract: manifest is authoritative; only an explicit CLI flag overrides (warns).
+    fps = float(_resolve_contract("fps", arg("fps"), manifest.get("fps")))
+    seq_len = int(_resolve_contract("seq_len", arg("seq_len"), manifest.get("seq_len")))
+    imgsz = int(_resolve_contract("imgsz", arg("imgsz"), manifest.get("imgsz")))
+    conf = float(_resolve_contract("conf", arg("conf"), manifest.get("conf")))
+    feature_set = str(_resolve_contract("feature_set", None, manifest.get("feature_set")))
+    screen_width = int(_resolve_contract("screen_width", None, manifest.get("screen_width")))
+    screen_height = int(_resolve_contract("screen_height", None, manifest.get("screen_height")))
+
+    cli_yolo = YOLO_SIZE_MAP.get(arg("yolo_size"), arg("yolo_size")) if arg("yolo_size") else None
+    yolo_weights = str(_resolve_contract("yolo_model", cli_yolo, manifest.get("yolo_model")))
+
+    # Mutable postprocess: CLI -> config -> manifest -> crash.
+    overlap = int(_resolve_mutable("overlap", arg("overlap"), cfg("overlap"), manifest.get("overlap")))
+    sigma = float(_resolve_mutable("sigma", arg("sigma"), cfg("sigma"), manifest.get("sigma")))
+    low = float(_resolve_mutable("low", arg("low"), cfg("low"), manifest.get("low")))
+    high = float(_resolve_mutable("high", arg("high"), cfg("high"), manifest.get("high")))
+    min_dur_sec = float(_resolve_mutable("min_dur_sec", arg("min_dur_sec"), cfg("min_dur_sec"), manifest.get("min_dur_sec")))
 
     return RunConfig(
         video_path=Path(video_path).expanduser().resolve(),
@@ -237,15 +323,18 @@ def build_run_config(args: argparse.Namespace) -> RunConfig:
         yolo_device=yolo_device,
         model_path=model_path,
         scaler_path=scaler_path,
-        fps=float(arg("fps") if arg("fps") is not None else cfg("fps", manifest_defaults.get("fps", 15.0))),
-        seq_len=int(arg("seq_len") if arg("seq_len") is not None else cfg("seq_len", manifest_defaults.get("seq_len", 300))),
-        overlap=int(arg("overlap") if arg("overlap") is not None else cfg("overlap", manifest_defaults.get("overlap", 150))),
-        sigma=float(arg("sigma") if arg("sigma") is not None else cfg("sigma", manifest_defaults.get("sigma", 1.5))),
-        low=float(arg("low") if arg("low") is not None else cfg("low", manifest_defaults.get("low", 0.45))),
-        high=float(arg("high") if arg("high") is not None else cfg("high", manifest_defaults.get("high", 0.8))),
-        min_dur_sec=float(arg("min_dur_sec") if arg("min_dur_sec") is not None else cfg("min_dur_sec", manifest_defaults.get("min_dur_sec", 0.5))),
-        conf=float(arg("conf") if arg("conf") is not None else cfg("conf", 0.25)),
-        imgsz=int(arg("imgsz") if arg("imgsz") is not None else cfg("imgsz", manifest_defaults.get("imgsz", 960))),
+        fps=fps,
+        seq_len=seq_len,
+        imgsz=imgsz,
+        conf=conf,
+        feature_set=feature_set,
+        screen_width=screen_width,
+        screen_height=screen_height,
+        overlap=overlap,
+        sigma=sigma,
+        low=low,
+        high=high,
+        min_dur_sec=min_dur_sec,
         start_time=int(arg("start_time") if arg("start_time") is not None else cfg("start_time", 0)),
         duration=int(arg("duration") if arg("duration") is not None else cfg("duration", 999999)),
     )
@@ -278,10 +367,23 @@ def run_pipeline(cfg: RunConfig) -> int:
         preprocessed_npz = tmp_dir / "preprocessed.npz"
         features_npz = tmp_dir / "features.npz"
 
-        pre = DataPreprocessor(save_court_masks=False)
+        pre = DataPreprocessor(
+            screen_width=int(cfg.screen_width),
+            screen_height=int(cfg.screen_height),
+            save_court_masks=False,
+        )
         pre.preprocess_single_video(raw_npz, str(cfg.video_path), str(preprocessed_npz), overwrite=True)
 
-        fe = FeatureEngineer(target_fps=float(cfg.fps))
+        if cfg.feature_set != "v1":
+            raise SystemExit(
+                f"This model declares feature_set='{cfg.feature_set}', but only 'v1' is implemented "
+                f"in the runtime. See docs/runtime-config-refactor-plan.md (§7, v0 backwards compat)."
+            )
+        fe = FeatureEngineer(
+            screen_width=int(cfg.screen_width),
+            screen_height=int(cfg.screen_height),
+            target_fps=float(cfg.fps),
+        )
         fe.create_features_from_preprocessed(str(preprocessed_npz), str(features_npz), overwrite=True)
 
         with np.load(str(features_npz)) as data:

--- a/src/preprocessing/court_detector_impl.py
+++ b/src/preprocessing/court_detector_impl.py
@@ -20,15 +20,17 @@ class CourtDetector:
     A class for detecting tennis court boundaries and estimating playable areas from video frames.
     """
     
-    def __init__(self, yolo_model_path: str = 'models/yolov8s-pose.pt'):
+    def __init__(self, yolo_model_path: str = 'models/yolov8s-pose.pt', conf: float = 0.25):
         """
         Initialize the CourtDetector.
-        
+
         Args:
             yolo_model_path: Path to the YOLO model file
+            conf: Person-detection confidence threshold (unified with the pose pipeline conf).
         """
         self.MIN_BASELINE_LEN = 500
         self.yolo_model_path = yolo_model_path
+        self.conf = float(conf)
         self.yolo_model = None
         
         # Initialize YOLO model if available
@@ -86,7 +88,7 @@ class CourtDetector:
                     cls_id = int(box.cls.item())
                     if cls_id == 0:  # person class
                         conf = float(box.conf.item())
-                        if conf > 0.5:  # confidence threshold
+                        if conf > self.conf:
                             xyxy = box.xyxy.cpu().numpy().reshape(-1)
                             x0, y0, x1, y1 = [int(v) for v in xyxy]
                             player_bboxes.append((x0, y0, x1-x0, y1-y0))
@@ -119,7 +121,7 @@ class CourtDetector:
                         cls_id = int(box.cls.item())
                         if cls_id == 0:  # person class
                             conf = float(box.conf.item())
-                            if conf > 0.5:
+                            if conf > self.conf:
                                 xyxy = box.xyxy.cpu().numpy().reshape(-1)
                                 x0, y0, x1, y1 = [int(v) for v in xyxy]
                                 candidate_bboxes.append((x0, y0, x1-x0, y1-y0))

--- a/src/preprocessing/court_detector_impl.py
+++ b/src/preprocessing/court_detector_impl.py
@@ -20,7 +20,7 @@ class CourtDetector:
     A class for detecting tennis court boundaries and estimating playable areas from video frames.
     """
     
-    def __init__(self, yolo_model_path: str = 'models/yolov8s-pose.pt', conf: float = 0.25):
+    def __init__(self, yolo_model_path: str = 'models/yolov8n-pose.pt', conf: float = 0.25):
         """
         Initialize the CourtDetector.
 

--- a/src/preprocessing/data_preprocessor.py
+++ b/src/preprocessing/data_preprocessor.py
@@ -6,12 +6,15 @@ from preprocessing.court_detector import CourtDetector
 
 
 class DataPreprocessor:
-    def __init__(self, screen_width: int = 1280, screen_height: int = 720, merge_iou_thresh: float = 0.6, save_court_masks: bool = False) -> None:
+    def __init__(self, screen_width: int = 1280, screen_height: int = 720, merge_iou_thresh: float = 0.6, save_court_masks: bool = False, yolo_model_path: str = "yolov8s-pose.pt") -> None:
         self.screen_width = screen_width
         self.screen_height = screen_height
         self.screen_center_x = screen_width / 2
         self.merge_iou_thresh = merge_iou_thresh
         self.save_court_masks = save_court_masks
+        # Court detection uses the SAME YOLO model as pose extraction (the one pinned in the
+        # model manifest) so there is one model in play and one auto-download, not two.
+        self.yolo_model_path = yolo_model_path
         self.left_zone_x = screen_width * 0.10
         self.right_zone_x = screen_width * 0.90
         self.bottom_zone_y = screen_height * 0.80
@@ -116,7 +119,7 @@ class DataPreprocessor:
 
     def generate_court_mask(self, video_path: str):
         try:
-            detector = CourtDetector(yolo_model_path='models/yolov8s-pose.pt')
+            detector = CourtDetector(yolo_model_path=self.yolo_model_path)
             mask, clean_frame, metadata = detector.process_video(video_path, target_time=60)
             return mask
         except Exception as e:

--- a/src/preprocessing/data_preprocessor.py
+++ b/src/preprocessing/data_preprocessor.py
@@ -6,15 +6,16 @@ from preprocessing.court_detector import CourtDetector
 
 
 class DataPreprocessor:
-    def __init__(self, screen_width: int = 1280, screen_height: int = 720, merge_iou_thresh: float = 0.6, save_court_masks: bool = False, yolo_model_path: str = "yolov8s-pose.pt") -> None:
+    def __init__(self, screen_width: int = 1280, screen_height: int = 720, merge_iou_thresh: float = 0.6, save_court_masks: bool = False, yolo_model_path: str = "yolov8s-pose.pt", conf: float = 0.25) -> None:
         self.screen_width = screen_width
         self.screen_height = screen_height
         self.screen_center_x = screen_width / 2
         self.merge_iou_thresh = merge_iou_thresh
         self.save_court_masks = save_court_masks
-        # Court detection uses the SAME YOLO model as pose extraction (the one pinned in the
-        # model manifest) so there is one model in play and one auto-download, not two.
+        # Court detection uses the SAME YOLO model + conf as pose extraction (the values
+        # pinned in the model manifest) so there is one model in play and one auto-download.
         self.yolo_model_path = yolo_model_path
+        self.conf = float(conf)
         self.left_zone_x = screen_width * 0.10
         self.right_zone_x = screen_width * 0.90
         self.bottom_zone_y = screen_height * 0.80
@@ -119,7 +120,7 @@ class DataPreprocessor:
 
     def generate_court_mask(self, video_path: str):
         try:
-            detector = CourtDetector(yolo_model_path=self.yolo_model_path)
+            detector = CourtDetector(yolo_model_path=self.yolo_model_path, conf=self.conf)
             mask, clean_frame, metadata = detector.process_video(video_path, target_time=60)
             return mask
         except Exception as e:

--- a/src/preprocessing/data_preprocessor.py
+++ b/src/preprocessing/data_preprocessor.py
@@ -6,7 +6,7 @@ from preprocessing.court_detector import CourtDetector
 
 
 class DataPreprocessor:
-    def __init__(self, screen_width: int = 1280, screen_height: int = 720, merge_iou_thresh: float = 0.6, save_court_masks: bool = False, yolo_model_path: str = "yolov8s-pose.pt", conf: float = 0.25) -> None:
+    def __init__(self, screen_width: int = 1280, screen_height: int = 720, merge_iou_thresh: float = 0.6, save_court_masks: bool = False, yolo_model_path: str = "yolov8n-pose.pt", conf: float = 0.25) -> None:
         self.screen_width = screen_width
         self.screen_height = screen_height
         self.screen_center_x = screen_width / 2

--- a/tests/helpers/runtime_fixtures.py
+++ b/tests/helpers/runtime_fixtures.py
@@ -326,6 +326,11 @@ def write_manifest_model_dir(path: Path) -> Path:
             "target_fps": FPS,
             "sample_fps": FPS,
             "imgsz": 960,
+            "conf": 0.25,
+            "num_keypoints": 17,
+            "screen_width": 1280,
+            "screen_height": 720,
+            "yolo_model": "yolov8n-pose.pt",
         },
         "inference": {
             "input_name": "features",

--- a/tests/test_cli_config_contract.py
+++ b/tests/test_cli_config_contract.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+import pytest
+
 from helpers.module_stubs import import_cli_main_with_stubs
 from helpers.runtime_fixtures import FPS, write_manifest_model_dir
 
@@ -16,6 +18,8 @@ def _args(**overrides):
         "csv_output_dir": None,
         "model_path": None,
         "scaler_path": None,
+        "artifact_dir": None,
+        "manifest_path": None,
         "yolo_size": None,
         "yolo_device": None,
         "fps": None,
@@ -26,6 +30,7 @@ def _args(**overrides):
         "high": None,
         "min_dur_sec": None,
         "conf": None,
+        "imgsz": None,
         "start_time": None,
         "duration": None,
         "write_csv": None,
@@ -47,50 +52,63 @@ def _asset_args(tmp_path, **overrides):
     )
 
 
-def test_quick_run_uses_manifest_defaults_for_bundled_onnx(tmp_path, monkeypatch):
+def test_quick_run_uses_manifest_contract_for_bundled_onnx(tmp_path, monkeypatch):
     cli_main = import_cli_main_with_stubs(monkeypatch)
     monkeypatch.chdir(tmp_path)
 
     cfg = cli_main.build_run_config(_asset_args(tmp_path))
 
+    # contract (immutable) comes from the manifest
     assert cfg.fps == FPS
     assert cfg.seq_len == 100
+    assert cfg.imgsz == 960
+    assert cfg.conf == 0.25
+    assert cfg.feature_set == "v1"
+    assert cfg.screen_width == 1280
+    assert cfg.screen_height == 720
+    assert cfg.yolo_weights == "yolov8n-pose.pt"
+    # postprocess (mutable) defaults from the manifest
     assert cfg.overlap == 50
     assert cfg.high == 0.7
     assert cfg.low == 0.45
     assert cfg.sigma == 1.0
     assert cfg.min_dur_sec == 1.0
-    assert cfg.imgsz == 960
 
 
-def test_explicit_config_can_override_manifest_defaults(tmp_path, monkeypatch):
+def test_config_overrides_mutable_but_never_contract(tmp_path, monkeypatch):
     cli_main = import_cli_main_with_stubs(monkeypatch)
     monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "custom.toml"
     config_path.write_text(
         """
 [run]
+# mutable postprocess — should win
+sigma = 1.5
+high = 0.8
+min_dur_sec = 0.5
+overlap = 150
+# contract — must be ignored (manifest is authoritative)
 fps = 15.0
 seq_len = 300
-overlap = 150
-high = 0.8
-sigma = 1.5
-min_dur_sec = 0.5
+imgsz = 1920
 """,
         encoding="utf-8",
     )
 
     cfg = cli_main.build_run_config(_asset_args(tmp_path, config=str(config_path)))
 
-    assert cfg.fps == 15.0
-    assert cfg.seq_len == 300
-    assert cfg.overlap == 150
-    assert cfg.high == 0.8
+    # mutable overrides applied
     assert cfg.sigma == 1.5
+    assert cfg.high == 0.8
     assert cfg.min_dur_sec == 0.5
+    assert cfg.overlap == 150
+    # contract stays pinned to the manifest despite config trying to override
+    assert cfg.fps == FPS
+    assert cfg.seq_len == 100
+    assert cfg.imgsz == 960
 
 
-def test_incidental_repo_config_toml_does_not_break_quick_run(tmp_path, monkeypatch):
+def test_incidental_repo_config_toml_cannot_corrupt_contract(tmp_path, monkeypatch):
     cli_main = import_cli_main_with_stubs(monkeypatch)
     monkeypatch.chdir(tmp_path)
     (tmp_path / "config.toml").write_text(
@@ -99,10 +117,8 @@ def test_incidental_repo_config_toml_does_not_break_quick_run(tmp_path, monkeypa
 video_path = "stale.mp4"
 fps = 15.0
 seq_len = 300
-overlap = 150
-high = 0.8
-sigma = 1.5
-min_dur_sec = 0.5
+imgsz = 1920
+conf = 0.5
 """,
         encoding="utf-8",
     )
@@ -111,10 +127,58 @@ min_dur_sec = 0.5
 
     assert cfg.fps == FPS
     assert cfg.seq_len == 100
-    assert cfg.overlap == 50
-    assert cfg.high == 0.7
-    assert cfg.sigma == 1.0
-    assert cfg.min_dur_sec == 1.0
+    assert cfg.imgsz == 960
+    assert cfg.conf == 0.25
+
+
+def test_cli_flag_overrides_contract_with_warning(tmp_path, monkeypatch, caplog):
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level("WARNING"):
+        cfg = cli_main.build_run_config(_asset_args(tmp_path, fps=15.0))
+
+    assert cfg.fps == 15.0  # explicit CLI override wins
+    assert any("contract field 'fps'" in r.message for r in caplog.records)
+
+
+def test_write_csv_from_config_honored_even_with_video(tmp_path, monkeypatch):
+    # Regression: --video used to skip config.toml entirely, silently dropping write_csv.
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.toml").write_text(
+        """
+[run]
+write_csv = true
+csv_output_dir = "from_config"
+""",
+        encoding="utf-8",
+    )
+
+    cfg = cli_main.build_run_config(_asset_args(tmp_path))
+
+    assert cfg.write_csv is True
+    assert cfg.csv_output_dir.name == "from_config"
+
+
+def test_missing_manifest_crashes_no_phantom_defaults(tmp_path, monkeypatch):
+    # A model artifact without a manifest must fail loudly, not fall back to stale literals.
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    model_dir = tmp_path / "models" / "bare"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"fake onnx")
+    (model_dir / "scaler.json").write_text("{}", encoding="utf-8")
+    video_path = tmp_path / "match.mp4"
+    video_path.write_bytes(b"fake video")
+    args = _args(
+        video=str(video_path),
+        model_path=str(model_dir / "model.onnx"),
+        scaler_path=str(model_dir / "scaler.json"),
+    )
+
+    with pytest.raises(SystemExit):
+        cli_main.build_run_config(args)
 
 
 def test_readme_documented_artifact_flags_are_supported_by_argparse(monkeypatch, tmp_path):

--- a/tests/test_cli_config_contract.py
+++ b/tests/test_cli_config_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 
 import pytest
@@ -201,3 +202,87 @@ def test_readme_documented_artifact_flags_are_supported_by_argparse(monkeypatch,
     monkeypatch.setattr(cli_main, "run_pipeline", lambda cfg: 0)
 
     assert cli_main.main() == 0
+
+
+def _complete_manifest():
+    return {
+        "feature_pipeline": {
+            "target_fps": 5.0, "imgsz": 960, "conf": 0.25, "feature_set": "v1",
+            "screen_width": 1280, "screen_height": 720, "yolo_model": "yolov8n-pose.pt",
+        },
+        "inference": {"seq_len_frames": 100, "overlap_frames": 50},
+        "postprocess": {"params": {"high": 0.7, "low": 0.45, "sigma": 1.0, "min_dur_sec": 1.0}},
+    }
+
+
+def _model_dir_with_manifest(tmp_path, payload, *, name="custom"):
+    """Write a model artifact dir whose manifest is `payload` (dict -> JSON, or raw str if malformed)."""
+    model_dir = tmp_path / "models" / name
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"fake onnx")
+    (model_dir / "scaler.json").write_text("{}", encoding="utf-8")
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    (model_dir / "manifest.json").write_text(text, encoding="utf-8")
+    return model_dir
+
+
+def _build_from_model_dir(cli_main, tmp_path, model_dir):
+    video_path = tmp_path / "match.mp4"
+    video_path.write_bytes(b"fake video")
+    return cli_main.build_run_config(_args(
+        video=str(video_path),
+        model_path=str(model_dir / "model.onnx"),
+        scaler_path=str(model_dir / "scaler.json"),
+    ))
+
+
+def test_missing_contract_field_without_flag_omits_flag_advice(tmp_path, monkeypatch):
+    # screen_width is manifest-only (no CLI flag); the error must not advertise --screen-width.
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    payload = _complete_manifest()
+    del payload["feature_pipeline"]["screen_width"]
+
+    with pytest.raises(SystemExit) as ei:
+        _build_from_model_dir(cli_main, tmp_path, _model_dir_with_manifest(tmp_path, payload))
+    msg = str(ei.value)
+    assert "screen_width" in msg
+    assert "--screen-width" not in msg
+    assert "manifest.json" in msg
+
+
+def test_missing_contract_field_with_flag_suggests_real_flag(tmp_path, monkeypatch):
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    payload = _complete_manifest()
+    del payload["feature_pipeline"]["target_fps"]
+
+    with pytest.raises(SystemExit) as ei:
+        _build_from_model_dir(cli_main, tmp_path, _model_dir_with_manifest(tmp_path, payload))
+    assert "--fps" in str(ei.value)
+
+
+def test_missing_yolo_model_suggests_yolo_size_flag(tmp_path, monkeypatch):
+    # yolo_model is overridden by --yolo-size, not a (nonexistent) --yolo-model.
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    payload = _complete_manifest()
+    del payload["feature_pipeline"]["yolo_model"]
+
+    with pytest.raises(SystemExit) as ei:
+        _build_from_model_dir(cli_main, tmp_path, _model_dir_with_manifest(tmp_path, payload))
+    msg = str(ei.value)
+    assert "--yolo-size" in msg
+    assert "--yolo-model" not in msg
+
+
+def test_malformed_manifest_warns_and_falls_back(tmp_path, monkeypatch, caplog):
+    # A present-but-corrupt manifest must warn, not silently masquerade as "missing field".
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    model_dir = _model_dir_with_manifest(tmp_path, "{ not valid json", name="broken")
+
+    with caplog.at_level("WARNING"):
+        values = cli_main._manifest_values(model_dir / "model.onnx", model_dir / "manifest.json")
+
+    assert values == {}
+    assert any("manifest" in r.getMessage().lower() for r in caplog.records)

--- a/tests/test_cli_pipeline_smoke.py
+++ b/tests/test_cli_pipeline_smoke.py
@@ -33,11 +33,13 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
             return str(tmp_path / "raw_pose.npz")
 
     class FakePreprocessor:
-        def __init__(self, save_court_masks, screen_width=None, screen_height=None, **_kwargs):
+        def __init__(self, save_court_masks, screen_width=None, screen_height=None, yolo_model_path=None, **_kwargs):
             calls.append("preprocess:init")
             assert save_court_masks is False
             assert screen_width == 1280
             assert screen_height == 720
+            # court detection uses the same manifest-pinned model as pose extraction
+            assert yolo_model_path == "yolov8n-pose.pt"
 
         def preprocess_single_video(self, raw_npz, video, output_npz, overwrite):
             calls.append("preprocess:run")

--- a/tests/test_cli_pipeline_smoke.py
+++ b/tests/test_cli_pipeline_smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from helpers.module_stubs import import_cli_main_with_stubs
 from helpers.runtime_fixtures import FEATURE_DIM
@@ -173,3 +174,59 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
     ]
     assert opened_npz
     assert all(npz.closed for npz in opened_npz)
+
+
+def test_unsupported_feature_set_fails_before_pose_extraction(tmp_path, monkeypatch):
+    # A v0 (or any non-v1) manifest must fail fast, before the expensive pose extraction runs.
+    cli_main = import_cli_main_with_stubs(monkeypatch)
+    video_path = tmp_path / "match.mp4"
+    model_path = tmp_path / "model.onnx"
+    scaler_path = tmp_path / "scaler.json"
+    video_path.write_bytes(b"fake video")
+    model_path.write_bytes(b"fake onnx")
+    scaler_path.write_text("{}", encoding="utf-8")
+
+    calls: list[str] = []
+
+    class ExplodingPoseExtractor:
+        def __init__(self, *args, **kwargs):
+            calls.append("pose:init")
+
+        def extract_pose_data(self, *args, **kwargs):
+            calls.append("pose:extract")
+            raise AssertionError("pose extraction must not run for an unsupported feature_set")
+
+    monkeypatch.setattr(cli_main, "PoseExtractor", ExplodingPoseExtractor)
+
+    cfg = cli_main.RunConfig(
+        video_path=video_path,
+        output_dir=tmp_path / "output_videos",
+        output_name=None,
+        csv_output_dir=tmp_path / "output_csvs",
+        write_csv=False,
+        segment_video=False,
+        yolo_weights="yolov8n-pose.pt",
+        yolo_device=None,
+        model_path=model_path,
+        scaler_path=scaler_path,
+        fps=5.0,
+        seq_len=100,
+        overlap=50,
+        sigma=1.0,
+        low=0.45,
+        high=0.7,
+        min_dur_sec=1.0,
+        conf=0.25,
+        imgsz=960,
+        feature_set="v0",
+        screen_width=1280,
+        screen_height=720,
+        start_time=0,
+        duration=999999,
+    )
+
+    with pytest.raises(SystemExit) as ei:
+        cli_main.run_pipeline(cfg)
+
+    assert "feature_set='v0'" in str(ei.value)
+    assert calls == []  # never reached pose extraction

--- a/tests/test_cli_pipeline_smoke.py
+++ b/tests/test_cli_pipeline_smoke.py
@@ -33,13 +33,14 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
             return str(tmp_path / "raw_pose.npz")
 
     class FakePreprocessor:
-        def __init__(self, save_court_masks, screen_width=None, screen_height=None, yolo_model_path=None, **_kwargs):
+        def __init__(self, save_court_masks, screen_width=None, screen_height=None, yolo_model_path=None, conf=None, **_kwargs):
             calls.append("preprocess:init")
             assert save_court_masks is False
             assert screen_width == 1280
             assert screen_height == 720
-            # court detection uses the same manifest-pinned model as pose extraction
+            # court detection uses the same manifest-pinned model + conf as pose extraction
             assert yolo_model_path == "yolov8n-pose.pt"
+            assert conf == 0.25
 
         def preprocess_single_video(self, raw_npz, video, output_npz, overwrite):
             calls.append("preprocess:run")

--- a/tests/test_cli_pipeline_smoke.py
+++ b/tests/test_cli_pipeline_smoke.py
@@ -33,9 +33,11 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
             return str(tmp_path / "raw_pose.npz")
 
     class FakePreprocessor:
-        def __init__(self, save_court_masks):
+        def __init__(self, save_court_masks, screen_width=None, screen_height=None, **_kwargs):
             calls.append("preprocess:init")
             assert save_court_masks is False
+            assert screen_width == 1280
+            assert screen_height == 720
 
         def preprocess_single_video(self, raw_npz, video, output_npz, overwrite):
             calls.append("preprocess:run")
@@ -143,6 +145,9 @@ def test_run_pipeline_wires_runtime_stages_and_closes_feature_npz(tmp_path, monk
         min_dur_sec=1.0,
         conf=0.25,
         imgsz=960,
+        feature_set="v1",
+        screen_width=1280,
+        screen_height=720,
         start_time=0,
         duration=999999,
     )

--- a/tests/test_runtime_preprocessing_contract.py
+++ b/tests/test_runtime_preprocessing_contract.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import importlib
+import inspect
+
 import numpy as np
+import pytest
 
 from helpers.module_stubs import import_data_preprocessor_with_stubs
 from helpers.runtime_fixtures import fake_yolo_result, write_raw_pose_npz
@@ -101,3 +105,17 @@ def test_runtime_preprocessor_closes_npz_file_handles(tmp_path, monkeypatch):
 
     assert opened
     assert all(npz.closed for npz in opened)
+
+
+def test_data_preprocessor_default_yolo_model_is_nano(monkeypatch):
+    # Direct instantiation must not silently fall back to the old "small" model (train/serve skew).
+    DataPreprocessor = import_data_preprocessor_with_stubs(monkeypatch).DataPreprocessor
+    default = inspect.signature(DataPreprocessor.__init__).parameters["yolo_model_path"].default
+    assert default.endswith("yolov8n-pose.pt"), default
+
+
+def test_court_detector_default_yolo_model_is_nano():
+    pytest.importorskip("cv2")
+    cdi = importlib.import_module("preprocessing.court_detector_impl")
+    default = inspect.signature(cdi.CourtDetector.__init__).parameters["yolo_model_path"].default
+    assert default.endswith("yolov8n-pose.pt"), default


### PR DESCRIPTION
## What & why

The inference pipeline had three sources of truth for the same parameters (manifest, config.toml, and hardcoded literals), and the literals encoded the **old v0.1 contract**. They agreed only on the bundled happy path; the moment the manifest was missing or `RunConfig` was built directly, the phantom v0.1 values silently took over. This PR makes the **manifest the single source of truth** for the model contract and removes the stale literals.

Full design + audit in [docs/runtime-config-refactor-plan.md](docs/runtime-config-refactor-plan.md). This is Phase 1.

## The model (config resolution split into three buckets)

| Bucket | Fields | Resolution |
|---|---|---|
| **Immutable contract** | fps, seq_len, imgsz, conf, feature_set, screen_w/h, yolo_model | manifest only; explicit CLI flag overrides (warns); **missing → crash** |
| **Mutable postprocess** | overlap, sigma, low, high, min_dur_sec | CLI → config → manifest → crash |
| **IO** | output, write_csv, etc. | CLI → config → default |

`RunConfig`'s contract/postprocess fields are now **required** — no phantom defaults. A stale `config.toml` can no longer corrupt the contract (contract keys there are ignored with a warning); only an explicit CLI flag overrides.

## Real bugs fixed along the way

- **YOLO model train/serve skew** — the model was trained on **nano**, but the CLI defaulted to **small**. Manifest now pins `yolo_model: yolov8n-pose.pt`.
- **Court detector** ran a *second, different* YOLO (`models/yolov8s-pose.pt`) on every inference → two models, two downloads. Now uses the same manifest-pinned model, and its person-detection `conf` is unified with the pose `conf` (0.25).
- **`write_csv` silently dropped** on `--video` runs (config.toml was skipped entirely). config.toml is always loaded now; the `--video` skip is deleted.
- **`screen_width/height`** were hardcoded; moved into the manifest and plumbed through `FeatureEngineer` + `DataPreprocessor`.
- Legacy `.pth`/`seq_len300` asset fallbacks dropped; `feature_set` guard fails loud (only `v1` implemented; v0 deferred — see plan §7).

## Manifest

Recorded the known-truth contract fields that were missing/`null` in `models/rallyclip_v0.3.1/manifest.json`: `conf=0.25`, `yolo_model=yolov8n-pose.pt`, `screen_width=1280`, `screen_height=720`, `num_keypoints=17`. Note: the training **export script** should emit these too, or the next exported model will be missing them and crash (follow-up).

## Tests

Full suite green (53 passed). Config-contract suite rewritten for the new semantics: config overrides mutable not contract, CLI override warns, missing-manifest crashes, `write_csv` honored with `--video`. Smoke test asserts the court detector gets the manifest model + conf.

## Not in scope

GUI (deprecated/broken static path), v0 backwards compat (fully spec'd but deferred, plan §7), Docker (Phase 2+ uses the validation harness as acceptance test).