### PR TITLE
feat(segment): re-encode cut with audio + sane bitrate (#10 topics 3+4)

### DIFF
--- a/src/segmentation/segment.py
+++ b/src/segmentation/segment.py
@@ -54,13 +54,19 @@ def segment_video(input_video: str, intervals: List[Tuple[float, float]], output
     starts = [s for s, _ in intervals]
 
     in_container = av.open(input_video)
-    out_container = av.open(output_path, 'w')
     try:
         in_v = next((s for s in in_container.streams if s.type == 'video'), None)
         if in_v is None:
             raise RuntimeError(f"No video stream found in {input_video}")
         in_a = next((s for s in in_container.streams if s.type == 'audio'), None)
+        # Open the output only after validating the input, so a no-video input doesn't
+        # leave a zero-byte file behind and a failed open doesn't leak in_container.
+        out_container = av.open(output_path, 'w')
+    except Exception:
+        in_container.close()
+        raise
 
+    try:
         rate = in_v.average_rate or Fraction(30, 1)
         video_tb = Fraction(1, 1) / rate  # 1/fps; kept frames get sequential pts in this base
         out_v = out_container.add_stream('libx264', rate=rate)

--- a/src/segmentation/segment.py
+++ b/src/segmentation/segment.py
@@ -1,9 +1,14 @@
+import bisect
 import csv
 import os
+from fractions import Fraction
 from typing import List, Tuple
 
 import av
-import cv2
+
+# libx264 quality. Lower = higher quality/larger; ~20 is near visually lossless and keeps the
+# output bitrate in the neighbourhood of a typical H.264 source (vs the old mp4v blow-up).
+DEFAULT_CRF = 20
 
 
 def load_intervals(csv_path: str) -> List[Tuple[float, float]]:
@@ -23,40 +28,100 @@ def load_intervals(csv_path: str) -> List[Tuple[float, float]]:
         return sorted(intervals, key=lambda x: (x[0], x[1]))
 
 
-def segment_video(input_video: str, intervals: List[Tuple[float, float]], output_path: str, eps: float = 1e-6) -> None:
+def _in_interval(t: float, intervals: List[Tuple[float, float]], starts: List[float], eps: float) -> bool:
+    """True if input time t (seconds) falls within any kept interval."""
+    k = bisect.bisect_right(starts, t + eps) - 1
+    if k < 0:
+        return False
+    start_t, end_t = intervals[k]
+    return (t + eps) >= start_t and (t - eps) <= end_t
+
+
+def segment_video(input_video: str, intervals: List[Tuple[float, float]], output_path: str,
+                  eps: float = 1e-6, crf: int = DEFAULT_CRF) -> None:
+    """Cut the kept intervals out of input_video and concatenate them into one output file.
+
+    Frame-accurate, re-encoded with libx264 (CRF) for video and AAC for audio, so the output
+    carries sound and stays near the source bitrate. Kept video/audio frames are re-stamped onto
+    a single gap-free timeline (sequential per stream) so the concatenated clips play back-to-back
+    in sync. Audio is optional — inputs without an audio stream produce a clean video-only file.
+    """
     if not intervals:
         raise ValueError("No intervals provided")
     os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+
+    intervals = sorted(intervals, key=lambda x: (x[0], x[1]))
+    starts = [s for s, _ in intervals]
+
     in_container = av.open(input_video)
-    in_stream = next(s for s in in_container.streams if s.type == 'video')
-    time_base = in_stream.time_base
-    avg_rate = in_stream.average_rate or 30
-    width = in_stream.codec_context.width
-    height = in_stream.codec_context.height
-    fps_out = float(avg_rate) if hasattr(avg_rate, '__float__') else float(avg_rate.numerator / avg_rate.denominator) if hasattr(avg_rate, 'numerator') else 30.0
-    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-    out_writer = cv2.VideoWriter(output_path, fourcc, fps_out, (width, height))
-    if not out_writer.isOpened():
-        raise RuntimeError(f"Failed to open video writer for {output_path}")
-    kept_frames = 0
-    idx = 0
-    n = len(intervals)
+    out_container = av.open(output_path, 'w')
     try:
-        for frame in in_container.decode(in_stream):
+        in_v = next((s for s in in_container.streams if s.type == 'video'), None)
+        if in_v is None:
+            raise RuntimeError(f"No video stream found in {input_video}")
+        in_a = next((s for s in in_container.streams if s.type == 'audio'), None)
+
+        rate = in_v.average_rate or Fraction(30, 1)
+        video_tb = Fraction(1, 1) / rate  # 1/fps; kept frames get sequential pts in this base
+        out_v = out_container.add_stream('libx264', rate=rate)
+        out_v.width = in_v.codec_context.width
+        out_v.height = in_v.codec_context.height
+        out_v.pix_fmt = 'yuv420p'
+        out_v.options = {'crf': str(crf)}
+
+        out_a = resampler = fifo = None
+        if in_a is not None:
+            out_a = out_container.add_stream('aac', rate=in_a.codec_context.sample_rate)
+            out_a.layout = in_a.layout
+            resampler = av.AudioResampler(format=out_a.format, layout=out_a.layout, rate=out_a.rate)
+            fifo = av.AudioFifo()
+
+        audio_pts = 0  # cumulative output samples => gap-free audio timeline
+
+        def drain_audio(flush: bool = False) -> None:
+            nonlocal audio_pts
+            frame_size = out_a.frame_size or 1024
+            while fifo.samples >= frame_size or (flush and fifo.samples > 0):
+                take = frame_size if fifo.samples >= frame_size else fifo.samples
+                a_frame = fifo.read(take)
+                if a_frame is None:
+                    break
+                a_frame.pts = audio_pts
+                a_frame.time_base = Fraction(1, out_a.rate)
+                audio_pts += a_frame.samples
+                for pkt in out_a.encode(a_frame):
+                    out_container.mux(pkt)
+
+        decode_streams = [s for s in (in_v, in_a) if s is not None]
+        v_index = 0
+        for frame in in_container.decode(*decode_streams):
             if frame.pts is None:
                 continue
-            t = float(frame.pts * time_base)
-            while idx < n and t > (intervals[idx][1] + eps):
-                idx += 1
-            if idx >= n:
-                break
-            start_t, end_t = intervals[idx]
-            if (t + eps) >= start_t and (t - eps) <= end_t:
-                kept_frames += 1
-                bgr_frame = frame.to_ndarray(format='bgr24')
-                out_writer.write(bgr_frame)
+            t = float(frame.pts * frame.time_base)
+            if not _in_interval(t, intervals, starts, eps):
+                continue
+            if isinstance(frame, av.VideoFrame):
+                frame.pts = v_index
+                frame.time_base = video_tb
+                frame.pict_type = av.video.frame.PictureType.NONE
+                v_index += 1
+                for pkt in out_v.encode(frame):
+                    out_container.mux(pkt)
+            elif out_a is not None and isinstance(frame, av.AudioFrame):
+                frame.pts = None
+                for r_frame in resampler.resample(frame):
+                    fifo.write(r_frame)
+                drain_audio()
+
+        # Flush video, then audio (resampler -> fifo -> encoder).
+        for pkt in out_v.encode():
+            out_container.mux(pkt)
+        if out_a is not None:
+            for r_frame in resampler.resample(None):
+                fifo.write(r_frame)
+            drain_audio(flush=True)
+            for pkt in out_a.encode():
+                out_container.mux(pkt)
     finally:
-        out_writer.release()
+        out_container.close()
         in_container.close()
-
-

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+av = pytest.importorskip("av")
+np = pytest.importorskip("numpy")
+
+from segmentation.segment import _in_interval, load_intervals, segment_video
+
+
+def _make_clip(path, seconds=12, fps=10, with_audio=True, sample_rate=48000):
+    """Generate a tiny test clip (solid color frames + optional 440Hz tone)."""
+    container = av.open(str(path), "w")
+    try:
+        v = container.add_stream("libx264", rate=fps)
+        v.width, v.height, v.pix_fmt = 320, 240, "yuv420p"
+        a = None
+        if with_audio:
+            a = container.add_stream("aac", rate=sample_rate)
+            a.layout = "stereo"
+
+        for i in range(seconds * fps):
+            arr = np.full((240, 320, 3), i % 256, dtype=np.uint8)
+            frame = av.VideoFrame.from_ndarray(arr, format="rgb24")
+            frame.pts = i
+            for pkt in v.encode(frame):
+                container.mux(pkt)
+        for pkt in v.encode():
+            container.mux(pkt)
+
+        if a is not None:
+            chunk = 1024
+            for start in range(0, seconds * sample_rate, chunk):
+                n = min(chunk, seconds * sample_rate - start)
+                tone = (0.1 * np.sin(2 * np.pi * 440 * np.arange(start, start + n) / sample_rate)).astype("float32")
+                af = av.AudioFrame.from_ndarray(np.stack([tone, tone]), format="fltp", layout="stereo")
+                af.sample_rate = sample_rate
+                af.pts = start
+                af.time_base = Fraction(1, sample_rate)
+                for pkt in a.encode(af):
+                    container.mux(pkt)
+            for pkt in a.encode():
+                container.mux(pkt)
+    finally:
+        container.close()
+
+
+def _streams_and_duration(path):
+    with av.open(str(path)) as c:
+        kinds = {s.type for s in c.streams}
+        duration = (c.duration or 0) / av.time_base
+    return kinds, duration
+
+
+def test_load_intervals(tmp_path):
+    csv_path = tmp_path / "segs.csv"
+    csv_path.write_text("start_time,end_time\n5.0,7.0\n1.0,2.0\nbad,row\n", encoding="utf-8")
+    assert load_intervals(str(csv_path)) == [(1.0, 2.0), (5.0, 7.0)]  # sorted, bad row skipped
+
+
+def test_segment_no_intervals_raises(tmp_path):
+    with pytest.raises(ValueError):
+        segment_video(str(tmp_path / "in.mp4"), [], str(tmp_path / "out.mp4"))
+
+
+def test_in_interval_boundaries():
+    intervals = [(1.0, 2.0), (5.0, 7.0)]
+    starts = [1.0, 5.0]
+    assert _in_interval(1.5, intervals, starts, 1e-6)
+    assert _in_interval(1.0, intervals, starts, 1e-6)  # inclusive start
+    assert _in_interval(7.0, intervals, starts, 1e-6)  # inclusive end
+    assert not _in_interval(3.0, intervals, starts, 1e-6)  # in the gap
+    assert not _in_interval(0.5, intervals, starts, 1e-6)  # before first
+
+
+def test_segment_carries_audio_and_concatenates(tmp_path):
+    src = tmp_path / "src.mp4"
+    try:
+        _make_clip(src, seconds=12, with_audio=True)
+    except Exception as exc:  # encoder not available in this build
+        pytest.skip(f"cannot encode test clip: {exc}")
+    out = tmp_path / "out.mp4"
+
+    segment_video(str(src), [(2.0, 4.0), (7.0, 9.0)], str(out))  # 4s total
+
+    kinds, duration = _streams_and_duration(out)
+    assert "video" in kinds and "audio" in kinds  # audio carried through (topic 3)
+    assert duration == pytest.approx(4.0, abs=0.3)  # frame-accurate concat
+
+
+def test_segment_video_only_input(tmp_path):
+    src = tmp_path / "src_noaudio.mp4"
+    try:
+        _make_clip(src, seconds=8, with_audio=False)
+    except Exception as exc:
+        pytest.skip(f"cannot encode test clip: {exc}")
+    out = tmp_path / "out.mp4"
+
+    segment_video(str(src), [(1.0, 3.0)], str(out))  # 2s
+
+    kinds, duration = _streams_and_duration(out)
+    assert kinds == {"video"}  # no audio stream, no crash
+    assert duration == pytest.approx(2.0, abs=0.3)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -47,6 +47,27 @@ def _make_clip(path, seconds=12, fps=10, with_audio=True, sample_rate=48000):
         container.close()
 
 
+def _make_audio_only(path, seconds=2, sample_rate=48000):
+    """Generate a clip with an audio stream but no video stream."""
+    container = av.open(str(path), "w")
+    try:
+        a = container.add_stream("aac", rate=sample_rate)
+        a.layout = "stereo"
+        for start in range(0, seconds * sample_rate, 1024):
+            n = min(1024, seconds * sample_rate - start)
+            silence = np.zeros(n, dtype="float32")
+            af = av.AudioFrame.from_ndarray(np.stack([silence, silence]), format="fltp", layout="stereo")
+            af.sample_rate = sample_rate
+            af.pts = start
+            af.time_base = Fraction(1, sample_rate)
+            for pkt in a.encode(af):
+                container.mux(pkt)
+        for pkt in a.encode():
+            container.mux(pkt)
+    finally:
+        container.close()
+
+
 def _streams_and_duration(path):
     with av.open(str(path)) as c:
         kinds = {s.type for s in c.streams}
@@ -103,3 +124,16 @@ def test_segment_video_only_input(tmp_path):
     kinds, duration = _streams_and_duration(out)
     assert kinds == {"video"}  # no audio stream, no crash
     assert duration == pytest.approx(2.0, abs=0.3)
+
+
+def test_segment_no_video_stream_raises_without_leaving_a_file(tmp_path):
+    src = tmp_path / "audio_only.mp4"
+    try:
+        _make_audio_only(src)
+    except Exception as exc:
+        pytest.skip(f"cannot encode test clip: {exc}")
+    out = tmp_path / "out.mp4"
+
+    with pytest.raises(RuntimeError):
+        segment_video(str(src), [(0.5, 1.0)], str(out))
+    assert not out.exists()  # no corrupt/zero-byte output left behind


### PR DESCRIPTION
## Summary
Fixes topics 3 + 4 of #10 — the silent, oversized output clips — by replacing `segment_video`'s `cv2.VideoWriter`/`mp4v` path with an in-process **PyAV** trim/concat re-encode.

- **Audio (topic 3):** the old path decoded only the video stream and wrote frames via `cv2.VideoWriter` (video-only) → silent output. Now both streams are read and the audio is muxed through, re-encoded to **AAC**. Inputs without audio still produce a clean video-only file.
- **Bitrate (topic 4):** `mp4v` at OpenCV defaults had no rate control (~1997 → 6548 kBit/s, ~3×). Now **libx264 CRF 20** keeps it near the source — measured **1308 → 1792 kBit/s (1.4×)** on a real clip.

Kept frames are re-stamped onto one **gap-free timeline** (sequential per stream) so the rally intervals play back-to-back in sync, **frame-accurate**, concatenated into the single `*_segmented.mp4` exactly as before. `segment_video(input, intervals, output)` signature unchanged — both callers ([cli/main.py](RallyClip/src/cli/main.py), [gui/app.py](RallyClip/src/gui/app.py)) untouched. `cv2` is dropped from `segment.py`.

## Why PyAV (not a system ffmpeg)
The runtime already decodes everything through PyAV (= ffmpeg's libraries, in-process); the cut now uses the same stack, so there's **no new dependency** and nothing extra to bundle — important for the on-device target.

## Verification
- Full suite **80 passed** (+11 e2e deselected).
- New `tests/test_segment.py`: `load_intervals`, no-intervals guard, `_in_interval` boundaries, **audio carry-through + concat duration**, and **video-only input** (self-contained PyAV clip generation; skips if encoders unavailable).
- Real clip: input h264+opus 1185s → cut `[(10,13),(30,33.5)]` → output **h264 + aac, duration 6.500s**, 1792 kBit/s.

Refs #10 (topics 3+4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
