### PR TITLE
Add quality e2e harness for CLI and release binaries

### DIFF
--- a/scripts/eval_quality.py
+++ b/scripts/eval_quality.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+from training.eval.quality_harness import RunnerConfig, run_quality_eval
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run RallyClip e2e quality evaluation and write a report.")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("tests/fixtures/quality/manifest.json"),
+        help="Quality fixture manifest",
+    )
+    parser.add_argument(
+        "--gt-dir",
+        type=Path,
+        default=Path("tests/fixtures/quality/gt"),
+        help="Directory containing GT JSON fixtures",
+    )
+    parser.add_argument(
+        "--video-dir",
+        type=Path,
+        default=Path(os.environ.get("RALLYCLIP_EVAL_VIDEO_DIR", "")),
+        help="Directory containing source videos",
+    )
+    parser.add_argument("--output", type=Path, default=Path("quality_report.json"), help="Report JSON path")
+    parser.add_argument("--runner", choices=["dev", "release"], default="dev")
+    parser.add_argument("--release-bin", type=Path, default=_env_path("RALLYCLIP_RELEASE_BIN"))
+    parser.add_argument(
+        "--command",
+        default=f"{sys.executable} -m cli.main",
+        help="Dev runner command, split with shell-like quoting",
+    )
+    parser.add_argument("--artifact-dir", type=Path, help="Model artifact directory to pass through to rallyclip")
+    args = parser.parse_args()
+
+    if not args.video_dir or not args.video_dir.is_dir():
+        raise SystemExit("Set --video-dir or RALLYCLIP_EVAL_VIDEO_DIR to the source video directory.")
+    extra_args = ("--artifact-dir", str(args.artifact_dir)) if args.artifact_dir else ()
+    if args.runner == "release":
+        if args.release_bin is None:
+            raise SystemExit("Set --release-bin or RALLYCLIP_RELEASE_BIN for release mode.")
+        runner = RunnerConfig(mode="release", release_bin=args.release_bin, extra_args=extra_args)
+    else:
+        runner = RunnerConfig(mode="dev", command=tuple(shlex.split(args.command)), extra_args=extra_args)
+
+    report = run_quality_eval(
+        manifest_path=args.manifest,
+        video_dir=args.video_dir,
+        gt_dir=args.gt_dir,
+        output_path=args.output,
+        runner=runner,
+    )
+    print(json.dumps(report["pooled"], indent=2, sort_keys=True))
+    print(f"Wrote {args.output}")
+    return 0
+
+
+def _env_path(name: str) -> Path | None:
+    raw = os.environ.get(name)
+    return Path(raw) if raw else None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pick_eval_windows.py
+++ b/scripts/pick_eval_windows.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pick RallyClip e2e quality-test windows from GT JSONs.")
+    parser.add_argument("annotations", nargs="+", type=Path, help="Ground-truth JSON files")
+    parser.add_argument("--duration", type=int, default=180, help="Window duration in seconds")
+    parser.add_argument("--min-points", type=int, default=8, help="Minimum fully-contained GT points")
+    parser.add_argument("--step", type=int, default=5, help="Candidate start-time step in seconds")
+    args = parser.parse_args()
+
+    entries = [pick_window(path, args.duration, args.min_points, args.step) for path in args.annotations]
+    print(json.dumps(entries, indent=2, ensure_ascii=False))
+    return 0
+
+
+def pick_window(path: Path, duration_s: int, min_points: int, step_s: int) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    segments = [
+        (float(segment["start_time"]), float(segment["end_time"]))
+        for segment in data.get("segments", [])
+        if float(segment["end_time"]) > float(segment["start_time"])
+    ]
+    if not segments:
+        raise ValueError(f"{path}: no valid segments")
+
+    last_end = max(end for _, end in segments)
+    midpoint = last_end / 2.0
+    best: tuple[float, int, list[tuple[float, float]]] | None = None
+    low = max(0, int(midpoint) - 900)
+    high = int(midpoint) + 900
+    for start in range(low, high + 1, step_s):
+        end = start + duration_s
+        straddles = any(seg_start < start < seg_end or seg_start < end < seg_end for seg_start, seg_end in segments)
+        if straddles:
+            continue
+        contained = [(seg_start, seg_end) for seg_start, seg_end in segments if seg_start >= start and seg_end <= end]
+        if len(contained) < min_points:
+            continue
+        distance = abs((start + duration_s / 2.0) - midpoint)
+        if best is None or distance < best[0]:
+            best = (distance, start, contained)
+
+    if best is None:
+        raise ValueError(f"{path}: no {duration_s}s window with at least {min_points} non-straddling segments")
+
+    _, start, contained = best
+    video_name = path.name.removesuffix(".json")
+    return {
+        "id": slugify(Path(video_name).stem),
+        "video": video_name,
+        "gt": path.name,
+        "start_time_s": start,
+        "duration_s": duration_s,
+        "gt_points_in_window": len(contained),
+    }
+
+
+def slugify(value: str) -> str:
+    out = []
+    last_was_sep = False
+    for ch in value.lower():
+        if ch.isalnum():
+            out.append(ch)
+            last_was_sep = False
+        elif not last_was_sep:
+            out.append("_")
+            last_was_sep = True
+    return "".join(out).strip("_")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/training/eval/quality_harness.py
+++ b/src/training/eval/quality_harness.py
@@ -160,6 +160,10 @@ def run_pipeline_to_csv(
         "--write-csv",
         "--csv-output-dir",
         str(csv_output_dir),
+        # Pin the output basename to the entry id so the expected CSV path
+        # doesn't depend on how the CLI treats exotic video filename stems.
+        "--output-name",
+        entry.id,
         "--no-segment-video",
     ]
     argv.extend(runner.extra_args)
@@ -169,7 +173,7 @@ def run_pipeline_to_csv(
             f"{entry.id}: pipeline failed with exit code {proc.returncode}\n"
             f"command: {' '.join(argv)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
         )
-    csv_path = csv_output_dir / f"{video_path.stem}_segments.csv"
+    csv_path = csv_output_dir / f"{entry.id}_segments.csv"
     if not csv_path.is_file():
         raise FileNotFoundError(
             f"{entry.id}: pipeline succeeded but did not write expected CSV: {csv_path}"
@@ -214,7 +218,9 @@ def load_segments_csv(path: Path) -> list[tuple[float, float]]:
     return segments
 
 
-def intervals_to_binary(segments: Iterable[tuple[float, float]], timestamps: np.ndarray) -> np.ndarray:
+def intervals_to_binary(segments: list[tuple[float, float]], timestamps: np.ndarray) -> np.ndarray:
+    # list, not Iterable: segments is re-consumed once per frame below, so a
+    # one-shot generator would silently classify every later frame as 0.
     binary = np.zeros(timestamps.shape, dtype=int)
     frame_intervals = _frame_intervals_from_timestamps(timestamps)
     for idx, (frame_start, frame_end) in enumerate(frame_intervals):

--- a/src/training/eval/quality_harness.py
+++ b/src/training/eval/quality_harness.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+from typing import Any, Iterable
+
+import numpy as np
+
+from training.metrics.segment import (
+    compute_time_point_classification_metrics,
+    compute_time_segment_metrics,
+)
+
+DEFAULT_FPS = 5.0
+DEFAULT_IOU_THRESHOLD = 0.5
+DEFAULT_WELL_COVERAGE_THRESHOLD = 0.9
+
+
+@dataclass(frozen=True)
+class QualityEntry:
+    id: str
+    video: str
+    gt: str
+    start_time_s: int
+    duration_s: int
+    gt_points_in_window: int
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    mode: str = "dev"
+    release_bin: Path | None = None
+    command: tuple[str, ...] = (sys.executable, "-m", "cli.main")
+    extra_args: tuple[str, ...] = ()
+
+
+def load_manifest(path: Path) -> list[QualityEntry]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return [QualityEntry(**entry) for entry in data]
+
+
+def run_quality_eval(
+    *,
+    manifest_path: Path,
+    video_dir: Path,
+    gt_dir: Path,
+    output_path: Path | None = None,
+    runner: RunnerConfig | None = None,
+    fps: float = DEFAULT_FPS,
+) -> dict[str, Any]:
+    entries = load_manifest(manifest_path)
+    runner = runner or RunnerConfig()
+
+    reports = [
+        evaluate_entry(
+            entry,
+            video_dir=video_dir,
+            gt_dir=gt_dir,
+            runner=runner,
+            fps=fps,
+        )
+        for entry in entries
+    ]
+    report = {
+        "runner": _runner_label(runner),
+        "manifest": _path_label(manifest_path),
+        "video_dir": _path_label(video_dir),
+        "gt_dir": _path_label(gt_dir),
+        "fps": fps,
+        "per_video": reports,
+        "pooled": _pool_reports(reports),
+    }
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def evaluate_entry(
+    entry: QualityEntry,
+    *,
+    video_dir: Path,
+    gt_dir: Path,
+    runner: RunnerConfig,
+    fps: float = DEFAULT_FPS,
+) -> dict[str, Any]:
+    video_path = video_dir / entry.video
+    gt_path = gt_dir / entry.gt
+    if not video_path.is_file():
+        raise FileNotFoundError(f"{entry.id}: source video missing: {video_path}")
+    if not gt_path.is_file():
+        raise FileNotFoundError(f"{entry.id}: ground-truth annotation missing: {gt_path}")
+
+    true_segments = load_windowed_gt_segments(
+        gt_path,
+        start_time_s=float(entry.start_time_s),
+        duration_s=float(entry.duration_s),
+    )
+    if len(true_segments) != int(entry.gt_points_in_window):
+        raise ValueError(
+            f"{entry.id}: expected {entry.gt_points_in_window} GT points after windowing, "
+            f"got {len(true_segments)}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix=f"rallyclip_quality_{entry.id}_") as tmp:
+        tmp_path = Path(tmp)
+        csv_path = run_pipeline_to_csv(
+            video_path=video_path,
+            entry=entry,
+            csv_output_dir=tmp_path,
+            runner=runner,
+        )
+        pred_segments = load_segments_csv(csv_path)
+
+    timestamps = _timestamps(float(entry.duration_s), float(fps))
+    true_binary = intervals_to_binary(true_segments, timestamps)
+    pred_binary = intervals_to_binary(pred_segments, timestamps)
+    segment_metrics = compute_time_segment_metrics(true_binary, pred_binary, timestamps)
+    point_metrics = compute_time_point_classification_metrics(
+        true_binary,
+        pred_binary,
+        timestamps,
+        iou_threshold=DEFAULT_IOU_THRESHOLD,
+        well_coverage_threshold=DEFAULT_WELL_COVERAGE_THRESHOLD,
+    )
+    return {
+        "id": entry.id,
+        "video": entry.video,
+        "start_time_s": entry.start_time_s,
+        "duration_s": entry.duration_s,
+        "gt_points_in_window": len(true_segments),
+        "pred_points": len(pred_segments),
+        "segment_metrics": segment_metrics,
+        "point_metrics": point_metrics,
+        "boundary_offsets": boundary_offsets(true_segments, pred_segments),
+    }
+
+
+def run_pipeline_to_csv(
+    *,
+    video_path: Path,
+    entry: QualityEntry,
+    csv_output_dir: Path,
+    runner: RunnerConfig,
+) -> Path:
+    argv = _runner_argv(runner) + [
+        "--video",
+        str(video_path),
+        "--start-time",
+        str(int(entry.start_time_s)),
+        "--duration",
+        str(int(entry.duration_s)),
+        "--write-csv",
+        "--csv-output-dir",
+        str(csv_output_dir),
+        "--no-segment-video",
+    ]
+    argv.extend(runner.extra_args)
+    proc = subprocess.run(argv, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{entry.id}: pipeline failed with exit code {proc.returncode}\n"
+            f"command: {' '.join(argv)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    csv_path = csv_output_dir / f"{video_path.stem}_segments.csv"
+    if not csv_path.is_file():
+        raise FileNotFoundError(
+            f"{entry.id}: pipeline succeeded but did not write expected CSV: {csv_path}"
+        )
+    return csv_path
+
+
+def load_windowed_gt_segments(
+    gt_path: Path,
+    *,
+    start_time_s: float,
+    duration_s: float,
+) -> list[tuple[float, float]]:
+    end_time_s = start_time_s + duration_s
+    data = json.loads(gt_path.read_text(encoding="utf-8"))
+    out: list[tuple[float, float]] = []
+    for seg in data.get("segments", []):
+        start = float(seg["start_time"])
+        end = float(seg["end_time"])
+        if end <= start:
+            continue
+        # Drop boundary-straddlers so the evaluation is about model behavior, not window cuts.
+        if start < start_time_s < end or start < end_time_s < end:
+            continue
+        if start >= start_time_s and end <= end_time_s:
+            out.append((start - start_time_s, end - start_time_s))
+    return out
+
+
+def load_segments_csv(path: Path) -> list[tuple[float, float]]:
+    segments: list[tuple[float, float]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            try:
+                start = float(row["start_time"])
+                end = float(row["end_time"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if end > start:
+                segments.append((start, end))
+    return segments
+
+
+def intervals_to_binary(segments: Iterable[tuple[float, float]], timestamps: np.ndarray) -> np.ndarray:
+    binary = np.zeros(timestamps.shape, dtype=int)
+    frame_intervals = _frame_intervals_from_timestamps(timestamps)
+    for idx, (frame_start, frame_end) in enumerate(frame_intervals):
+        if any(_interval_overlap((frame_start, frame_end), seg) > 0.0 for seg in segments):
+            binary[idx] = 1
+    return binary
+
+
+def boundary_offsets(
+    true_segments: list[tuple[float, float]],
+    pred_segments: list[tuple[float, float]],
+) -> dict[str, Any]:
+    matched: list[dict[str, float]] = []
+    used_pred: set[int] = set()
+    for true_seg in true_segments:
+        best_idx = None
+        best_iou = 0.0
+        for pred_idx, pred_seg in enumerate(pred_segments):
+            if pred_idx in used_pred:
+                continue
+            iou = _interval_iou(true_seg, pred_seg)
+            if iou > best_iou:
+                best_iou = iou
+                best_idx = pred_idx
+        if best_idx is None or best_iou <= 0.0:
+            continue
+        used_pred.add(best_idx)
+        pred_seg = pred_segments[best_idx]
+        matched.append(
+            {
+                "iou": best_iou,
+                "start_offset_s": pred_seg[0] - true_seg[0],
+                "end_offset_s": pred_seg[1] - true_seg[1],
+            }
+        )
+    return {
+        "matched_points": len(matched),
+        "mean_start_offset_s": _mean([m["start_offset_s"] for m in matched]),
+        "mean_end_offset_s": _mean([m["end_offset_s"] for m in matched]),
+        "p90_abs_start_offset_s": _percentile_abs([m["start_offset_s"] for m in matched], 90),
+        "p90_abs_end_offset_s": _percentile_abs([m["end_offset_s"] for m in matched], 90),
+        "matches": matched,
+    }
+
+
+def _pool_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
+    count_keys = (
+        "total_true_points",
+        "total_pred_points",
+        "well_classified_points",
+        "cut_off_points",
+        "missed_points",
+        "false_detected_points",
+        "unmatched_predicted_points",
+    )
+    pooled = {key: 0 for key in count_keys}
+    for report in reports:
+        metrics = report["point_metrics"]
+        for key in count_keys:
+            pooled[key] += int(metrics.get(key, 0))
+
+    total_true = pooled["total_true_points"]
+    total_pred = pooled["total_pred_points"]
+    pooled.update(
+        {
+            "well_classified_rate": pooled["well_classified_points"] / total_true if total_true else 0.0,
+            "cut_off_rate": pooled["cut_off_points"] / total_true if total_true else 0.0,
+            "missed_rate": pooled["missed_points"] / total_true if total_true else 0.0,
+            "false_detected_rate": pooled["false_detected_points"] / total_pred if total_pred else 0.0,
+            "unmatched_predicted_rate": pooled["unmatched_predicted_points"] / total_pred if total_pred else 0.0,
+            "segment_f1_mean": _mean([r["segment_metrics"]["segment_f1"] for r in reports]),
+            "segment_recall_mean": _mean([r["segment_metrics"]["segment_recall"] for r in reports]),
+            "segment_precision_mean": _mean([r["segment_metrics"]["segment_precision"] for r in reports]),
+        }
+    )
+    return pooled
+
+
+def _runner_argv(runner: RunnerConfig) -> list[str]:
+    if runner.mode == "release":
+        if runner.release_bin is None:
+            raise ValueError("release runner requires release_bin")
+        return [str(runner.release_bin), "--cli"]
+    if runner.mode == "dev":
+        return list(runner.command)
+    raise ValueError(f"unknown runner mode: {runner.mode}")
+
+
+def _runner_label(runner: RunnerConfig) -> dict[str, Any]:
+    return {
+        "mode": runner.mode,
+        "release_bin": _path_label(runner.release_bin) if runner.release_bin is not None else None,
+        "command": [_path_label(Path(arg)) if Path(arg).is_absolute() else arg for arg in runner.command],
+        "extra_args": list(runner.extra_args),
+    }
+
+
+def _path_label(path: Path) -> str:
+    return str(path) if not path.is_absolute() else path.name
+
+
+def _timestamps(duration_s: float, fps: float) -> np.ndarray:
+    step = 1.0 / fps
+    count = max(1, int(round(duration_s * fps)))
+    return np.arange(count, dtype=np.float64) * step
+
+
+def _frame_intervals_from_timestamps(timestamps: np.ndarray) -> list[tuple[float, float]]:
+    if timestamps.size == 1:
+        return [(float(timestamps[0]), float(timestamps[0]) + 1.0)]
+    step = max(1e-6, float(timestamps[1] - timestamps[0]))
+    return [(float(t - step / 2.0), float(t + step / 2.0)) for t in timestamps]
+
+
+def _interval_iou(seg_a: tuple[float, float], seg_b: tuple[float, float]) -> float:
+    overlap = _interval_overlap(seg_a, seg_b)
+    union = (seg_a[1] - seg_a[0]) + (seg_b[1] - seg_b[0]) - overlap
+    return overlap / union if union > 0 else 0.0
+
+
+def _interval_overlap(seg_a: tuple[float, float], seg_b: tuple[float, float]) -> float:
+    return max(0.0, min(seg_a[1], seg_b[1]) - max(seg_a[0], seg_b[0]))
+
+
+def _mean(values: Iterable[float]) -> float:
+    values = list(values)
+    return float(mean(values)) if values else 0.0
+
+
+def _percentile_abs(values: Iterable[float], percentile: float) -> float:
+    values = [abs(v) for v in values]
+    if not values:
+        return 0.0
+    return float(np.percentile(np.asarray(values, dtype=np.float64), percentile))
+
+
+def runner_from_env(mode: str, extra_args: Iterable[str] = ()) -> RunnerConfig:
+    if mode == "release":
+        raw = os.environ.get("RALLYCLIP_RELEASE_BIN")
+        if not raw:
+            raise ValueError("set RALLYCLIP_RELEASE_BIN to use release mode")
+        return RunnerConfig(mode="release", release_bin=Path(raw), extra_args=tuple(extra_args))
+    return RunnerConfig(mode="dev", extra_args=tuple(extra_args))

--- a/tests/fixtures/quality/baseline.json
+++ b/tests/fixtures/quality/baseline.json
@@ -1,0 +1,220 @@
+{
+  "fps": 5.0,
+  "gt_dir": "tests/fixtures/quality/gt",
+  "manifest": "tests/fixtures/quality/manifest.json",
+  "per_video": [
+    {
+      "boundary_offsets": {
+        "matched_points": 5,
+        "mean_end_offset_s": 0.7804000000000082,
+        "mean_start_offset_s": 0.6929999999999973,
+        "p90_abs_end_offset_s": 1.4808000000000021,
+        "p90_abs_start_offset_s": 1.8371999999999957
+      },
+      "duration_s": 180,
+      "gt_points_in_window": 8,
+      "id": "9515_singles_uncut",
+      "point_metrics": {
+        "cut_off_points": 2,
+        "cut_off_rate": 0.25,
+        "false_detected_points": 0,
+        "false_detected_rate": 0.0,
+        "missed_points": 3,
+        "missed_rate": 0.375,
+        "total_pred_points": 5,
+        "total_true_points": 8,
+        "unmatched_predicted_points": 1,
+        "unmatched_predicted_rate": 0.2,
+        "well_classified_points": 3,
+        "well_classified_rate": 0.375
+      },
+      "pred_points": 5,
+      "segment_metrics": {
+        "coverage": 0.6312849162011174,
+        "mean_iou": 0.8056471720264845,
+        "segment_f1": 0.6153846153846154,
+        "segment_precision": 0.8,
+        "segment_recall": 0.5,
+        "specificity": 0.9694868238557559
+      },
+      "start_time_s": 215,
+      "video": "9\u29f85\u29f815 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4"
+    },
+    {
+      "boundary_offsets": {
+        "matched_points": 8,
+        "mean_end_offset_s": 0.3806897500000106,
+        "mean_start_offset_s": 0.02654587500000627,
+        "p90_abs_end_offset_s": 0.5155981000000155,
+        "p90_abs_start_offset_s": 0.10451569999995626
+      },
+      "duration_s": 180,
+      "gt_points_in_window": 8,
+      "id": "aditi_narayan_matchplay",
+      "point_metrics": {
+        "cut_off_points": 0,
+        "cut_off_rate": 0.0,
+        "false_detected_points": 0,
+        "false_detected_rate": 0.0,
+        "missed_points": 0,
+        "missed_rate": 0.0,
+        "total_pred_points": 8,
+        "total_true_points": 8,
+        "unmatched_predicted_points": 0,
+        "unmatched_predicted_rate": 0.0,
+        "well_classified_points": 8,
+        "well_classified_rate": 1.0
+      },
+      "pred_points": 8,
+      "segment_metrics": {
+        "coverage": 0.9929824561403513,
+        "mean_iou": 0.9371640456317885,
+        "segment_f1": 1.0,
+        "segment_precision": 1.0,
+        "segment_recall": 1.0,
+        "specificity": 0.9739837398373985
+      },
+      "start_time_s": 460,
+      "video": "Aditi Narayan \uff5c Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4"
+    },
+    {
+      "boundary_offsets": {
+        "matched_points": 8,
+        "mean_end_offset_s": 0.436223499999977,
+        "mean_start_offset_s": 0.027548499999981046,
+        "p90_abs_end_offset_s": 0.8289062000000218,
+        "p90_abs_start_offset_s": 0.38333660000001935
+      },
+      "duration_s": 180,
+      "gt_points_in_window": 8,
+      "id": "holly_schlatter_matchplay",
+      "point_metrics": {
+        "cut_off_points": 1,
+        "cut_off_rate": 0.125,
+        "false_detected_points": 0,
+        "false_detected_rate": 0.0,
+        "missed_points": 0,
+        "missed_rate": 0.0,
+        "total_pred_points": 8,
+        "total_true_points": 8,
+        "unmatched_predicted_points": 0,
+        "unmatched_predicted_rate": 0.0,
+        "well_classified_points": 7,
+        "well_classified_rate": 0.875
+      },
+      "pred_points": 8,
+      "segment_metrics": {
+        "coverage": 0.9770114942528736,
+        "mean_iou": 0.88875274122807,
+        "segment_f1": 1.0,
+        "segment_precision": 1.0,
+        "segment_recall": 1.0,
+        "specificity": 0.9655712050078243
+      },
+      "start_time_s": 1033,
+      "video": "Holly Schlatter \uff5c 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4"
+    },
+    {
+      "boundary_offsets": {
+        "matched_points": 8,
+        "mean_end_offset_s": 0.7752500000000038,
+        "mean_start_offset_s": 0.21675000000000355,
+        "p90_abs_end_offset_s": 1.2604999999999777,
+        "p90_abs_start_offset_s": 0.43259999999998455
+      },
+      "duration_s": 180,
+      "gt_points_in_window": 8,
+      "id": "otto_friedlein_matchplay",
+      "point_metrics": {
+        "cut_off_points": 1,
+        "cut_off_rate": 0.125,
+        "false_detected_points": 0,
+        "false_detected_rate": 0.0,
+        "missed_points": 0,
+        "missed_rate": 0.0,
+        "total_pred_points": 8,
+        "total_true_points": 8,
+        "unmatched_predicted_points": 0,
+        "unmatched_predicted_rate": 0.0,
+        "well_classified_points": 7,
+        "well_classified_rate": 0.875
+      },
+      "pred_points": 8,
+      "segment_metrics": {
+        "coverage": 0.9608540925266906,
+        "mean_iou": 0.8319868870019205,
+        "segment_f1": 1.0,
+        "segment_precision": 1.0,
+        "segment_recall": 1.0,
+        "specificity": 0.9483037156704363
+      },
+      "start_time_s": 755,
+      "video": "Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4"
+    },
+    {
+      "boundary_offsets": {
+        "matched_points": 8,
+        "mean_end_offset_s": 0.29759400000002634,
+        "mean_start_offset_s": -0.056986125000013654,
+        "p90_abs_end_offset_s": 0.6070214000000405,
+        "p90_abs_start_offset_s": 0.6532771000000379
+      },
+      "duration_s": 180,
+      "gt_points_in_window": 8,
+      "id": "satoru_nakajima_matchplay",
+      "point_metrics": {
+        "cut_off_points": 0,
+        "cut_off_rate": 0.0,
+        "false_detected_points": 0,
+        "false_detected_rate": 0.0,
+        "missed_points": 0,
+        "missed_rate": 0.0,
+        "total_pred_points": 8,
+        "total_true_points": 8,
+        "unmatched_predicted_points": 0,
+        "unmatched_predicted_rate": 0.0,
+        "well_classified_points": 8,
+        "well_classified_rate": 1.0
+      },
+      "pred_points": 8,
+      "segment_metrics": {
+        "coverage": 0.9771863117870726,
+        "mean_iou": 0.8962656922686714,
+        "segment_f1": 1.0,
+        "segment_precision": 1.0,
+        "segment_recall": 1.0,
+        "specificity": 0.9670329670329667
+      },
+      "start_time_s": 930,
+      "video": "Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4"
+    }
+  ],
+  "pooled": {
+    "cut_off_points": 4,
+    "cut_off_rate": 0.1,
+    "false_detected_points": 0,
+    "false_detected_rate": 0.0,
+    "missed_points": 3,
+    "missed_rate": 0.075,
+    "segment_f1_mean": 0.9230769230769231,
+    "segment_precision_mean": 0.96,
+    "segment_recall_mean": 0.9,
+    "total_pred_points": 37,
+    "total_true_points": 40,
+    "unmatched_predicted_points": 1,
+    "unmatched_predicted_rate": 0.02702702702702703,
+    "well_classified_points": 33,
+    "well_classified_rate": 0.825
+  },
+  "runner": {
+    "command": [
+      "python",
+      "-m",
+      "cli.main"
+    ],
+    "extra_args": [],
+    "mode": "dev",
+    "release_bin": null
+  },
+  "video_dir": "raw_videos"
+}

--- a/tests/fixtures/quality/gt/9⧸5⧸15 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4.json
+++ b/tests/fixtures/quality/gt/9⧸5⧸15 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4.json
@@ -1,0 +1,221 @@
+{
+  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/9\u29f85\u29f815 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4",
+  "segments": [
+    {
+      "start_time": 3.405,
+      "end_time": 7.658,
+      "label": "in_play"
+    },
+    {
+      "start_time": 30.792,
+      "end_time": 34.432,
+      "label": "in_play"
+    },
+    {
+      "start_time": 54.046,
+      "end_time": 56.596,
+      "label": "in_play"
+    },
+    {
+      "start_time": 63.935,
+      "end_time": 70.925,
+      "label": "in_play"
+    },
+    {
+      "start_time": 94.248,
+      "end_time": 98.846,
+      "label": "in_play"
+    },
+    {
+      "start_time": 114.816,
+      "end_time": 122.052,
+      "label": "in_play"
+    },
+    {
+      "start_time": 146.426,
+      "end_time": 149.184,
+      "label": "in_play"
+    },
+    {
+      "start_time": 157.605,
+      "end_time": 170.529,
+      "label": "in_play"
+    },
+    {
+      "start_time": 216.623,
+      "end_time": 219.419,
+      "label": "in_play"
+    },
+    {
+      "start_time": 195.73,
+      "end_time": 198.847,
+      "label": "in_play"
+    },
+    {
+      "start_time": 233.671,
+      "end_time": 236.227,
+      "label": "in_play"
+    },
+    {
+      "start_time": 243.851,
+      "end_time": 255.027,
+      "label": "in_play"
+    },
+    {
+      "start_time": 281.704,
+      "end_time": 285.454,
+      "label": "in_play"
+    },
+    {
+      "start_time": 293.697,
+      "end_time": 299.717,
+      "label": "in_play"
+    },
+    {
+      "start_time": 326.818,
+      "end_time": 330.124,
+      "label": "in_play"
+    },
+    {
+      "start_time": 341.247,
+      "end_time": 343.854,
+      "label": "in_play"
+    },
+    {
+      "start_time": 384.86,
+      "end_time": 386.681,
+      "label": "in_play"
+    },
+    {
+      "start_time": 406.265,
+      "end_time": 410.066,
+      "label": "in_play"
+    },
+    {
+      "start_time": 424.298,
+      "end_time": 437.92,
+      "label": "in_play"
+    },
+    {
+      "start_time": 458.831,
+      "end_time": 488.626,
+      "label": "in_play"
+    },
+    {
+      "start_time": 512.441,
+      "end_time": 514.361,
+      "label": "in_play"
+    },
+    {
+      "start_time": 518.921,
+      "end_time": 532.542,
+      "label": "in_play"
+    },
+    {
+      "start_time": 566.009,
+      "end_time": 568.897,
+      "label": "in_play"
+    },
+    {
+      "start_time": 585.713,
+      "end_time": 588.422,
+      "label": "in_play"
+    },
+    {
+      "start_time": 600.275,
+      "end_time": 614.064,
+      "label": "in_play"
+    },
+    {
+      "start_time": 643.808,
+      "end_time": 652.581,
+      "label": "in_play"
+    },
+    {
+      "start_time": 670.15,
+      "end_time": 678.341,
+      "label": "in_play"
+    },
+    {
+      "start_time": 806.328,
+      "end_time": 809.627,
+      "label": "in_play"
+    },
+    {
+      "start_time": 820.748,
+      "end_time": 826.618,
+      "label": "in_play"
+    },
+    {
+      "start_time": 839.744,
+      "end_time": 841.876,
+      "label": "in_play"
+    },
+    {
+      "start_time": 856.582,
+      "end_time": 864.43,
+      "label": "in_play"
+    },
+    {
+      "start_time": 886.5,
+      "end_time": 888.091,
+      "label": "in_play"
+    },
+    {
+      "start_time": 903.057,
+      "end_time": 907.931,
+      "label": "in_play"
+    },
+    {
+      "start_time": 915.065,
+      "end_time": 917.115,
+      "label": "in_play"
+    },
+    {
+      "start_time": 934.224,
+      "end_time": 941.805,
+      "label": "in_play"
+    },
+    {
+      "start_time": 961.492,
+      "end_time": 964.482,
+      "label": "in_play"
+    },
+    {
+      "start_time": 972.642,
+      "end_time": 980.851,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1002.903,
+      "end_time": 1006.247,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1014.416,
+      "end_time": 1017.928,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1038.521,
+      "end_time": 1047.14,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1068.099,
+      "end_time": 1071.3,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1082.633,
+      "end_time": 1094.049,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1112.293,
+      "end_time": 1118.736,
+      "label": "in_play"
+    }
+  ],
+  "metadata": {}
+}

--- a/tests/fixtures/quality/gt/9⧸5⧸15 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4.json
+++ b/tests/fixtures/quality/gt/9⧸5⧸15 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4.json
@@ -1,5 +1,4 @@
 {
-  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/9\u29f85\u29f815 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4",
   "segments": [
     {
       "start_time": 3.405,

--- a/tests/fixtures/quality/gt/Aditi Narayan ｜ Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4.json
+++ b/tests/fixtures/quality/gt/Aditi Narayan ｜ Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4.json
@@ -1,5 +1,4 @@
 {
-  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Aditi Narayan \uff5c Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4",
   "segments": [
     {
       "start_time": 4.220474,

--- a/tests/fixtures/quality/gt/Aditi Narayan ｜ Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4.json
+++ b/tests/fixtures/quality/gt/Aditi Narayan ｜ Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4.json
@@ -1,0 +1,251 @@
+{
+  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Aditi Narayan \uff5c Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4",
+  "segments": [
+    {
+      "start_time": 4.220474,
+      "end_time": 17.265099,
+      "label": "in_play"
+    },
+    {
+      "start_time": 38.451591,
+      "end_time": 43.447445,
+      "label": "in_play"
+    },
+    {
+      "start_time": 63.151813,
+      "end_time": 68.100734,
+      "label": "in_play"
+    },
+    {
+      "start_time": 89.458978,
+      "end_time": 94.107372,
+      "label": "in_play"
+    },
+    {
+      "start_time": 119.343177,
+      "end_time": 122.597019,
+      "label": "in_play"
+    },
+    {
+      "start_time": 143.990095,
+      "end_time": 147.89165,
+      "label": "in_play"
+    },
+    {
+      "start_time": 154.179887,
+      "end_time": 160.787228,
+      "label": "in_play"
+    },
+    {
+      "start_time": 183.031548,
+      "end_time": 192.724717,
+      "label": "in_play"
+    },
+    {
+      "start_time": 211.615727,
+      "end_time": 220.686195,
+      "label": "in_play"
+    },
+    {
+      "start_time": 239.949784,
+      "end_time": 244.749374,
+      "label": "in_play"
+    },
+    {
+      "start_time": 247.961646,
+      "end_time": 253.221985,
+      "label": "in_play"
+    },
+    {
+      "start_time": 274.693034,
+      "end_time": 279.405634,
+      "label": "in_play"
+    },
+    {
+      "start_time": 293.593823,
+      "end_time": 302.420483,
+      "label": "in_play"
+    },
+    {
+      "start_time": 319.197203,
+      "end_time": 322.273788,
+      "label": "in_play"
+    },
+    {
+      "start_time": 356.616926,
+      "end_time": 363.983415,
+      "label": "in_play"
+    },
+    {
+      "start_time": 380.073424,
+      "end_time": 383.906421,
+      "label": "in_play"
+    },
+    {
+      "start_time": 397.010888,
+      "end_time": 402.76674,
+      "label": "in_play"
+    },
+    {
+      "start_time": 428.095773,
+      "end_time": 434.586741,
+      "label": "in_play"
+    },
+    {
+      "start_time": 450.890886,
+      "end_time": 454.707336,
+      "label": "in_play"
+    },
+    {
+      "start_time": 461.038785,
+      "end_time": 468.06416,
+      "label": "in_play"
+    },
+    {
+      "start_time": 489.510334,
+      "end_time": 495.474723,
+      "label": "in_play"
+    },
+    {
+      "start_time": 515.194262,
+      "end_time": 519.902263,
+      "label": "in_play"
+    },
+    {
+      "start_time": 541.650596,
+      "end_time": 547.897443,
+      "label": "in_play"
+    },
+    {
+      "start_time": 559.899924,
+      "end_time": 563.614982,
+      "label": "in_play"
+    },
+    {
+      "start_time": 566.987578,
+      "end_time": 579.493077,
+      "label": "in_play"
+    },
+    {
+      "start_time": 608.821029,
+      "end_time": 613.730749,
+      "label": "in_play"
+    },
+    {
+      "start_time": 624.885125,
+      "end_time": 635.177085,
+      "label": "in_play"
+    },
+    {
+      "start_time": 659.707902,
+      "end_time": 667.77531,
+      "label": "in_play"
+    },
+    {
+      "start_time": 685.8413,
+      "end_time": 689.517273,
+      "label": "in_play"
+    },
+    {
+      "start_time": 692.75828,
+      "end_time": 699.356986,
+      "label": "in_play"
+    },
+    {
+      "start_time": 726.752233,
+      "end_time": 730.415888,
+      "label": "in_play"
+    },
+    {
+      "start_time": 748.112191,
+      "end_time": 753.904541,
+      "label": "in_play"
+    },
+    {
+      "start_time": 768.409937,
+      "end_time": 772.676691,
+      "label": "in_play"
+    },
+    {
+      "start_time": 792.590274,
+      "end_time": 797.635607,
+      "label": "in_play"
+    },
+    {
+      "start_time": 811.290943,
+      "end_time": 815.799852,
+      "label": "in_play"
+    },
+    {
+      "start_time": 821.342666,
+      "end_time": 825.754624,
+      "label": "in_play"
+    },
+    {
+      "start_time": 845.756735,
+      "end_time": 849.733409,
+      "label": "in_play"
+    },
+    {
+      "start_time": 853.041684,
+      "end_time": 860.761379,
+      "label": "in_play"
+    },
+    {
+      "start_time": 906.807046,
+      "end_time": 919.282621,
+      "label": "in_play"
+    },
+    {
+      "start_time": 940.098623,
+      "end_time": 945.619509,
+      "label": "in_play"
+    },
+    {
+      "start_time": 951.131161,
+      "end_time": 958.629239,
+      "label": "in_play"
+    },
+    {
+      "start_time": 975.525785,
+      "end_time": 980.454486,
+      "label": "in_play"
+    },
+    {
+      "start_time": 985.684862,
+      "end_time": 992.764576,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1020.158792,
+      "end_time": 1024.284929,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1029.867208,
+      "end_time": 1037.455173,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1057.545377,
+      "end_time": 1064.422441,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1083.596365,
+      "end_time": 1089.020403,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1113.378515,
+      "end_time": 1123.091176,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1133.38003,
+      "end_time": 1138.084719,
+      "label": "in_play"
+    }
+  ],
+  "metadata": {}
+}

--- a/tests/fixtures/quality/gt/Holly Schlatter ｜ 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4.json
+++ b/tests/fixtures/quality/gt/Holly Schlatter ｜ 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4.json
@@ -1,0 +1,401 @@
+{
+  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Holly Schlatter \uff5c 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4",
+  "segments": [
+    {
+      "start_time": 21.992296,
+      "end_time": 27.404093,
+      "label": "in_play"
+    },
+    {
+      "start_time": 45.6171,
+      "end_time": 50.070592,
+      "label": "in_play"
+    },
+    {
+      "start_time": 74.725864,
+      "end_time": 78.08319,
+      "label": "in_play"
+    },
+    {
+      "start_time": 83.686471,
+      "end_time": 95.088677,
+      "label": "in_play"
+    },
+    {
+      "start_time": 115.364011,
+      "end_time": 118.429239,
+      "label": "in_play"
+    },
+    {
+      "start_time": 123.626224,
+      "end_time": 130.894483,
+      "label": "in_play"
+    },
+    {
+      "start_time": 147.914515,
+      "end_time": 170.057434,
+      "label": "in_play"
+    },
+    {
+      "start_time": 190.240047,
+      "end_time": 196.085154,
+      "label": "in_play"
+    },
+    {
+      "start_time": 212.3114,
+      "end_time": 217.607082,
+      "label": "in_play"
+    },
+    {
+      "start_time": 230.640276,
+      "end_time": 240.573033,
+      "label": "in_play"
+    },
+    {
+      "start_time": 322.076712,
+      "end_time": 348.821955,
+      "label": "in_play"
+    },
+    {
+      "start_time": 364.216594,
+      "end_time": 368.920622,
+      "label": "in_play"
+    },
+    {
+      "start_time": 374.215187,
+      "end_time": 391.740168,
+      "label": "in_play"
+    },
+    {
+      "start_time": 406.857192,
+      "end_time": 412.62928,
+      "label": "in_play"
+    },
+    {
+      "start_time": 419.555079,
+      "end_time": 433.797703,
+      "label": "in_play"
+    },
+    {
+      "start_time": 454.459925,
+      "end_time": 460.524592,
+      "label": "in_play"
+    },
+    {
+      "start_time": 464.956675,
+      "end_time": 477.49277,
+      "label": "in_play"
+    },
+    {
+      "start_time": 504.117016,
+      "end_time": 513.407848,
+      "label": "in_play"
+    },
+    {
+      "start_time": 527.231357,
+      "end_time": 540.273359,
+      "label": "in_play"
+    },
+    {
+      "start_time": 579.485214,
+      "end_time": 582.397267,
+      "label": "in_play"
+    },
+    {
+      "start_time": 595.079982,
+      "end_time": 598.533876,
+      "label": "in_play"
+    },
+    {
+      "start_time": 603.135092,
+      "end_time": 606.305009,
+      "label": "in_play"
+    },
+    {
+      "start_time": 631.345719,
+      "end_time": 636.535189,
+      "label": "in_play"
+    },
+    {
+      "start_time": 646.196638,
+      "end_time": 658.288143,
+      "label": "in_play"
+    },
+    {
+      "start_time": 676.497331,
+      "end_time": 679.901226,
+      "label": "in_play"
+    },
+    {
+      "start_time": 699.029368,
+      "end_time": 703.497443,
+      "label": "in_play"
+    },
+    {
+      "start_time": 846.552266,
+      "end_time": 850.865249,
+      "label": "in_play"
+    },
+    {
+      "start_time": 863.104469,
+      "end_time": 872.529417,
+      "label": "in_play"
+    },
+    {
+      "start_time": 890.577384,
+      "end_time": 902.819725,
+      "label": "in_play"
+    },
+    {
+      "start_time": 916.342574,
+      "end_time": 922.730984,
+      "label": "in_play"
+    },
+    {
+      "start_time": 928.697495,
+      "end_time": 939.633524,
+      "label": "in_play"
+    },
+    {
+      "start_time": 958.051448,
+      "end_time": 963.380252,
+      "label": "in_play"
+    },
+    {
+      "start_time": 977.173341,
+      "end_time": 982.844052,
+      "label": "in_play"
+    },
+    {
+      "start_time": 993.802271,
+      "end_time": 1008.511569,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1035.492179,
+      "end_time": 1038.741784,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1042.443904,
+      "end_time": 1046.405178,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1067.822367,
+      "end_time": 1072.078493,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1090.74203,
+      "end_time": 1093.681843,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1098.026722,
+      "end_time": 1112.048599,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1138.443975,
+      "end_time": 1145.348903,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1162.153102,
+      "end_time": 1165.713848,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1170.055333,
+      "end_time": 1181.691564,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1313.119859,
+      "end_time": 1332.563261,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1355.325808,
+      "end_time": 1360.364455,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1366.981504,
+      "end_time": 1371.476056,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1393.280064,
+      "end_time": 1399.612595,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1414.540659,
+      "end_time": 1418.975337,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1434.415474,
+      "end_time": 1440.760757,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1447.405894,
+      "end_time": 1464.24454,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1487.107167,
+      "end_time": 1513.323945,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1532.674378,
+      "end_time": 1553.043084,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1566.628128,
+      "end_time": 1578.450268,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1596.017825,
+      "end_time": 1601.03931,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1605.889384,
+      "end_time": 1611.282185,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1634.885188,
+      "end_time": 1651.83245,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1673.24417,
+      "end_time": 1684.43074,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1698.791766,
+      "end_time": 1704.759959,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1709.865066,
+      "end_time": 1715.557748,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1750.253705,
+      "end_time": 1761.95284,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1785.886873,
+      "end_time": 1793.777359,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1805.364217,
+      "end_time": 1808.359607,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1814.026554,
+      "end_time": 1818.901328,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1840.897499,
+      "end_time": 1843.936078,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1856.3159,
+      "end_time": 1862.455141,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1885.165477,
+      "end_time": 1889.323804,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1894.150465,
+      "end_time": 1908.065361,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1935.740114,
+      "end_time": 1938.711438,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1942.184118,
+      "end_time": 1944.947477,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2073.069969,
+      "end_time": 2099.773533,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2115.698058,
+      "end_time": 2119.190726,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2133.627574,
+      "end_time": 2158.35273,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2186.408056,
+      "end_time": 2223.692225,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2244.23173,
+      "end_time": 2249.797872,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2261.612251,
+      "end_time": 2266.076015,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2280.284549,
+      "end_time": 2297.952479,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2321.855357,
+      "end_time": 2325.95867,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2332.173807,
+      "end_time": 2339.523868,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2361.43297,
+      "end_time": 2367.817449,
+      "label": "in_play"
+    },
+    {
+      "start_time": 2388.305053,
+      "end_time": 2396.334518,
+      "label": "in_play"
+    }
+  ],
+  "metadata": {}
+}

--- a/tests/fixtures/quality/gt/Holly Schlatter ｜ 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4.json
+++ b/tests/fixtures/quality/gt/Holly Schlatter ｜ 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4.json
@@ -1,5 +1,4 @@
 {
-  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Holly Schlatter \uff5c 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4",
   "segments": [
     {
       "start_time": 21.992296,

--- a/tests/fixtures/quality/gt/Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4.json
+++ b/tests/fixtures/quality/gt/Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4.json
@@ -1,5 +1,4 @@
 {
-  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4",
   "segments": [
     {
       "start_time": 6.683,

--- a/tests/fixtures/quality/gt/Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4.json
+++ b/tests/fixtures/quality/gt/Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4.json
@@ -1,0 +1,261 @@
+{
+  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4",
+  "segments": [
+    {
+      "start_time": 6.683,
+      "end_time": 10.253,
+      "label": "in_play"
+    },
+    {
+      "start_time": 15.409,
+      "end_time": 29.455,
+      "label": "in_play"
+    },
+    {
+      "start_time": 52.116,
+      "end_time": 54.899,
+      "label": "in_play"
+    },
+    {
+      "start_time": 61.663,
+      "end_time": 66.848,
+      "label": "in_play"
+    },
+    {
+      "start_time": 81.784,
+      "end_time": 95.35,
+      "label": "in_play"
+    },
+    {
+      "start_time": 111.574,
+      "end_time": 121.296,
+      "label": "in_play"
+    },
+    {
+      "start_time": 152.479,
+      "end_time": 169.903,
+      "label": "in_play"
+    },
+    {
+      "start_time": 194.905,
+      "end_time": 198.195,
+      "label": "in_play"
+    },
+    {
+      "start_time": 214.597,
+      "end_time": 221.945,
+      "label": "in_play"
+    },
+    {
+      "start_time": 242.042,
+      "end_time": 246.979,
+      "label": "in_play"
+    },
+    {
+      "start_time": 266.17,
+      "end_time": 268.949,
+      "label": "in_play"
+    },
+    {
+      "start_time": 284.101,
+      "end_time": 287.206,
+      "label": "in_play"
+    },
+    {
+      "start_time": 305.088,
+      "end_time": 307.932,
+      "label": "in_play"
+    },
+    {
+      "start_time": 314.808,
+      "end_time": 326.411,
+      "label": "in_play"
+    },
+    {
+      "start_time": 354.629,
+      "end_time": 359.899,
+      "label": "in_play"
+    },
+    {
+      "start_time": 384.814,
+      "end_time": 389.167,
+      "label": "in_play"
+    },
+    {
+      "start_time": 403.391,
+      "end_time": 440.472,
+      "label": "in_play"
+    },
+    {
+      "start_time": 474.245,
+      "end_time": 496.815,
+      "label": "in_play"
+    },
+    {
+      "start_time": 505.721,
+      "end_time": 515.105,
+      "label": "in_play"
+    },
+    {
+      "start_time": 542.791,
+      "end_time": 557.062,
+      "label": "in_play"
+    },
+    {
+      "start_time": 567.643,
+      "end_time": 575.52,
+      "label": "in_play"
+    },
+    {
+      "start_time": 591.934,
+      "end_time": 598.766,
+      "label": "in_play"
+    },
+    {
+      "start_time": 614.33,
+      "end_time": 620.208,
+      "label": "in_play"
+    },
+    {
+      "start_time": 636.317,
+      "end_time": 646.066,
+      "label": "in_play"
+    },
+    {
+      "start_time": 676.522,
+      "end_time": 679.571,
+      "label": "in_play"
+    },
+    {
+      "start_time": 687.538,
+      "end_time": 703.463,
+      "label": "in_play"
+    },
+    {
+      "start_time": 729.59,
+      "end_time": 744.17,
+      "label": "in_play"
+    },
+    {
+      "start_time": 770.249,
+      "end_time": 773.116,
+      "label": "in_play"
+    },
+    {
+      "start_time": 786.849,
+      "end_time": 794.525,
+      "label": "in_play"
+    },
+    {
+      "start_time": 812.055,
+      "end_time": 823.777,
+      "label": "in_play"
+    },
+    {
+      "start_time": 853.243,
+      "end_time": 856.898,
+      "label": "in_play"
+    },
+    {
+      "start_time": 866.04,
+      "end_time": 868.852,
+      "label": "in_play"
+    },
+    {
+      "start_time": 874.577,
+      "end_time": 888.655,
+      "label": "in_play"
+    },
+    {
+      "start_time": 908.569,
+      "end_time": 914.443,
+      "label": "in_play"
+    },
+    {
+      "start_time": 926.284,
+      "end_time": 931.932,
+      "label": "in_play"
+    },
+    {
+      "start_time": 950.416,
+      "end_time": 953.024,
+      "label": "in_play"
+    },
+    {
+      "start_time": 959.075,
+      "end_time": 964.528,
+      "label": "in_play"
+    },
+    {
+      "start_time": 986.875,
+      "end_time": 990.856,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1004.847,
+      "end_time": 1012.126,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1031.865,
+      "end_time": 1038.913,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1068.113,
+      "end_time": 1071.069,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1079.232,
+      "end_time": 1099.342,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1126.981,
+      "end_time": 1129.659,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1136.958,
+      "end_time": 1156.137,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1181.909,
+      "end_time": 1185.772,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1206.992,
+      "end_time": 1243.369,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1267.708,
+      "end_time": 1270.694,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1279.157,
+      "end_time": 1309.608,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1342.722,
+      "end_time": 1354.0,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1381.393,
+      "end_time": 1384.143,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1399.508,
+      "end_time": 1426.121,
+      "label": "in_play"
+    }
+  ],
+  "metadata": {}
+}

--- a/tests/fixtures/quality/gt/Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4.json
+++ b/tests/fixtures/quality/gt/Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4.json
@@ -1,5 +1,4 @@
 {
-  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4",
   "segments": [
     {
       "start_time": 25.703329,

--- a/tests/fixtures/quality/gt/Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4.json
+++ b/tests/fixtures/quality/gt/Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4.json
@@ -1,0 +1,281 @@
+{
+  "video_path": "/Users/ismaelrobles-razzaq/cs_projects/RallyClip/data/raw_videos/Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4",
+  "segments": [
+    {
+      "start_time": 25.703329,
+      "end_time": 45.16392,
+      "label": "in_play"
+    },
+    {
+      "start_time": 69.595699,
+      "end_time": 85.840987,
+      "label": "in_play"
+    },
+    {
+      "start_time": 123.42583,
+      "end_time": 126.800549,
+      "label": "in_play"
+    },
+    {
+      "start_time": 134.410936,
+      "end_time": 139.169225,
+      "label": "in_play"
+    },
+    {
+      "start_time": 159.845565,
+      "end_time": 164.153305,
+      "label": "in_play"
+    },
+    {
+      "start_time": 175.947261,
+      "end_time": 181.889927,
+      "label": "in_play"
+    },
+    {
+      "start_time": 206.497988,
+      "end_time": 209.408596,
+      "label": "in_play"
+    },
+    {
+      "start_time": 219.687308,
+      "end_time": 222.160103,
+      "label": "in_play"
+    },
+    {
+      "start_time": 247.60821,
+      "end_time": 253.175881,
+      "label": "in_play"
+    },
+    {
+      "start_time": 275.348034,
+      "end_time": 279.310549,
+      "label": "in_play"
+    },
+    {
+      "start_time": 286.30988,
+      "end_time": 290.28477,
+      "label": "in_play"
+    },
+    {
+      "start_time": 312.725892,
+      "end_time": 321.586309,
+      "label": "in_play"
+    },
+    {
+      "start_time": 537.196618,
+      "end_time": 557.888802,
+      "label": "in_play"
+    },
+    {
+      "start_time": 575.456878,
+      "end_time": 578.952559,
+      "label": "in_play"
+    },
+    {
+      "start_time": 584.625113,
+      "end_time": 597.424904,
+      "label": "in_play"
+    },
+    {
+      "start_time": 622.41062,
+      "end_time": 632.525728,
+      "label": "in_play"
+    },
+    {
+      "start_time": 654.959679,
+      "end_time": 657.881431,
+      "label": "in_play"
+    },
+    {
+      "start_time": 660.859219,
+      "end_time": 670.907221,
+      "label": "in_play"
+    },
+    {
+      "start_time": 690.77971,
+      "end_time": 694.522405,
+      "label": "in_play"
+    },
+    {
+      "start_time": 703.127742,
+      "end_time": 713.873158,
+      "label": "in_play"
+    },
+    {
+      "start_time": 770.344767,
+      "end_time": 779.462189,
+      "label": "in_play"
+    },
+    {
+      "start_time": 800.051257,
+      "end_time": 807.812922,
+      "label": "in_play"
+    },
+    {
+      "start_time": 878.409671,
+      "end_time": 887.699727,
+      "label": "in_play"
+    },
+    {
+      "start_time": 910.163203,
+      "end_time": 915.716427,
+      "label": "in_play"
+    },
+    {
+      "start_time": 939.70675,
+      "end_time": 944.859886,
+      "label": "in_play"
+    },
+    {
+      "start_time": 954.003897,
+      "end_time": 957.529687,
+      "label": "in_play"
+    },
+    {
+      "start_time": 967.274002,
+      "end_time": 977.60131,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1000.455971,
+      "end_time": 1006.456361,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1034.724837,
+      "end_time": 1038.598196,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1051.571727,
+      "end_time": 1059.451529,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1086.174856,
+      "end_time": 1090.353409,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1095.743849,
+      "end_time": 1105.96887,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1128.405369,
+      "end_time": 1131.231813,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1136.112447,
+      "end_time": 1141.94234,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1167.766104,
+      "end_time": 1171.438606,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1190.304711,
+      "end_time": 1193.108152,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1198.916938,
+      "end_time": 1203.036502,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1226.594285,
+      "end_time": 1232.257235,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1335.730083,
+      "end_time": 1341.821974,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1373.436751,
+      "end_time": 1381.017927,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1413.346222,
+      "end_time": 1417.131061,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1427.839759,
+      "end_time": 1433.915229,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1461.26926,
+      "end_time": 1465.160559,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1479.810914,
+      "end_time": 1483.300201,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1491.645222,
+      "end_time": 1495.174972,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1525.135417,
+      "end_time": 1530.969971,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1551.209642,
+      "end_time": 1555.072642,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1563.096635,
+      "end_time": 1570.901356,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1593.967088,
+      "end_time": 1597.716571,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1606.973353,
+      "end_time": 1610.648629,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1615.341987,
+      "end_time": 1619.420295,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1662.534585,
+      "end_time": 1674.126626,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1689.78486,
+      "end_time": 1693.884119,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1706.955255,
+      "end_time": 1710.944213,
+      "label": "in_play"
+    },
+    {
+      "start_time": 1718.232799,
+      "end_time": 1722.285778,
+      "label": "in_play"
+    }
+  ],
+  "metadata": {}
+}

--- a/tests/fixtures/quality/manifest.json
+++ b/tests/fixtures/quality/manifest.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "9515_singles_uncut",
+    "video": "9⧸5⧸15 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4",
+    "gt": "9⧸5⧸15 Singles Uncut_dur_4m35s_24m_24s_utr3_genM_courtH_OUT_angleMED_zoomIN.mp4.json",
+    "start_time_s": 215,
+    "duration_s": 180,
+    "gt_points_in_window": 8
+  },
+  {
+    "id": "aditi_narayan_matchplay",
+    "video": "Aditi Narayan ｜ Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4",
+    "gt": "Aditi Narayan ｜ Matchplay_utr6_genF_courtH_IN_angleMED_zoomMED.mp4.json",
+    "start_time_s": 460,
+    "duration_s": 180,
+    "gt_points_in_window": 8
+  },
+  {
+    "id": "holly_schlatter_matchplay",
+    "video": "Holly Schlatter ｜ 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4",
+    "gt": "Holly Schlatter ｜ 2021 Australian Tennis Recruit  - Match Play Footage_utr7_genF_courtH_OUT_angleHIGH_zoomOUT.mp4.json",
+    "start_time_s": 1033,
+    "duration_s": 180,
+    "gt_points_in_window": 8
+  },
+  {
+    "id": "otto_friedlein_matchplay",
+    "video": "Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4",
+    "gt": "Otto Friedlein - unedited matchplay_utr12_genM_courtH_IN_angleHIGH_zoomOUT.mp4.json",
+    "start_time_s": 755,
+    "duration_s": 180,
+    "gt_points_in_window": 8
+  },
+  {
+    "id": "satoru_nakajima_matchplay",
+    "video": "Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4",
+    "gt": "Satoru Nakajima (11.75 UTR) Match Video (Unedited) vs. Dylan Chou (11.14 UTR) November 5, 2023_utr11_genM_courtH_OUT_angleHIGH_zoomIN.mp4.json",
+    "start_time_s": 930,
+    "duration_s": 180,
+    "gt_points_in_window": 8
+  }
+]

--- a/tests/helpers/quality_fixtures.py
+++ b/tests/helpers/quality_fixtures.py
@@ -27,7 +27,7 @@ def resolve_artifact_dir() -> Path | None:
     raw = os.environ.get("RALLYCLIP_EVAL_ARTIFACT_DIR")
     if not raw:
         return None
-    path = Path(raw).expanduser()
-    if not path.is_dir():
-        raise FileNotFoundError(f"RALLYCLIP_EVAL_ARTIFACT_DIR is not a directory: {path}")
-    return path
+    # No existence check here: this runs at pytest collection time (module
+    # level), where raising would break the whole session. A bad path fails
+    # loudly inside the test via the CLI's own asset resolution instead.
+    return Path(raw).expanduser()

--- a/tests/helpers/quality_fixtures.py
+++ b/tests/helpers/quality_fixtures.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+FIX_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "quality"
+
+
+def load_manifest() -> list[dict]:
+    return json.loads((FIX_DIR / "manifest.json").read_text(encoding="utf-8"))
+
+
+def resolve_video_dir() -> Path | None:
+    raw = os.environ.get("RALLYCLIP_EVAL_VIDEO_DIR")
+    path = Path(raw).expanduser() if raw else None
+    return path if path and path.is_dir() else None
+
+
+def resolve_release_bin() -> Path | None:
+    raw = os.environ.get("RALLYCLIP_RELEASE_BIN")
+    path = Path(raw).expanduser() if raw else None
+    return path if path and path.is_file() else None
+
+
+def resolve_artifact_dir() -> Path | None:
+    raw = os.environ.get("RALLYCLIP_EVAL_ARTIFACT_DIR")
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    if not path.is_dir():
+        raise FileNotFoundError(f"RALLYCLIP_EVAL_ARTIFACT_DIR is not a directory: {path}")
+    return path

--- a/tests/test_quality_e2e.py
+++ b/tests/test_quality_e2e.py
@@ -1,0 +1,112 @@
+"""End-to-end quality checks for the RallyClip inference pipeline.
+
+These tests use a small, fixed subset of the training/validation annotations. That is
+intentional: this suite gates pipeline health and packaging regressions, not ML
+generalization. Real model selection should use the separate training eval workflow.
+
+Examples:
+  RALLYCLIP_EVAL_VIDEO_DIR=/path/to/raw_videos pytest tests/test_quality_e2e.py -q
+  RALLYCLIP_EVAL_VIDEO_DIR=/path/to/raw_videos RALLYCLIP_EVAL_ARTIFACT_DIR=models/new_model pytest tests/test_quality_e2e.py -q
+  RALLYCLIP_EVAL_VIDEO_DIR=/path/to/raw_videos RALLYCLIP_RELEASE_BIN=/path/to/RallyClip pytest tests/test_quality_e2e.py -q
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from helpers.quality_fixtures import (
+    FIX_DIR,
+    load_manifest,
+    resolve_artifact_dir,
+    resolve_release_bin,
+    resolve_video_dir,
+)
+from training.eval.quality_harness import (
+    QualityEntry,
+    RunnerConfig,
+    run_pipeline_to_csv,
+    run_quality_eval,
+)
+
+VIDEO_DIR = resolve_video_dir()
+RELEASE_BIN = resolve_release_bin()
+ARTIFACT_DIR = resolve_artifact_dir()
+MANIFEST = load_manifest()
+BASELINE_PATH = FIX_DIR / "baseline.json"
+ARTIFACT_ARGS = ("--artifact-dir", str(ARTIFACT_DIR)) if ARTIFACT_DIR is not None else ()
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(VIDEO_DIR is None, reason="set RALLYCLIP_EVAL_VIDEO_DIR to the source videos"),
+]
+
+
+def test_quality_smoke_writes_csv(tmp_path):
+    entry_data = dict(MANIFEST[0])
+    entry_data["duration_s"] = 60
+    entry = QualityEntry(**entry_data)
+
+    csv_path = run_pipeline_to_csv(
+        video_path=VIDEO_DIR / entry.video,
+        entry=entry,
+        csv_output_dir=tmp_path,
+        runner=RunnerConfig(mode="dev", extra_args=ARTIFACT_ARGS),
+    )
+
+    rows = csv_path.read_text(encoding="utf-8").strip().splitlines()
+    assert rows[0] == "start_time,end_time"
+    assert len(rows) > 1, f"{entry.id}: smoke run wrote no predicted segments"
+
+
+@pytest.fixture(scope="module", params=["dev", "release"])
+def quality_report(request, tmp_path_factory):
+    mode = request.param
+    if mode == "release" and RELEASE_BIN is None:
+        pytest.skip("set RALLYCLIP_RELEASE_BIN to run release-binary quality checks")
+    runner = (
+        RunnerConfig(mode="release", release_bin=RELEASE_BIN, extra_args=ARTIFACT_ARGS)
+        if mode == "release"
+        else RunnerConfig(mode="dev", extra_args=ARTIFACT_ARGS)
+    )
+    output_path = tmp_path_factory.mktemp(f"quality_{mode}") / "report.json"
+    return run_quality_eval(
+        manifest_path=FIX_DIR / "manifest.json",
+        video_dir=VIDEO_DIR,
+        gt_dir=FIX_DIR / "gt",
+        output_path=output_path,
+        runner=runner,
+    )
+
+
+@pytest.fixture(scope="module")
+def baseline():
+    if not BASELINE_PATH.is_file():
+        pytest.skip("baseline fixture missing; run scripts/eval_quality.py and commit baseline.json")
+    return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+def test_quality_good_rate_floor(quality_report, baseline):
+    floor = max(0.0, float(baseline["pooled"]["well_classified_rate"]) - 0.15)
+    assert quality_report["pooled"]["well_classified_rate"] >= floor
+
+
+def test_quality_missed_ceiling(quality_report, baseline):
+    ceiling = int(baseline["pooled"]["missed_points"]) + 2
+    assert quality_report["pooled"]["missed_points"] <= ceiling
+
+
+def test_quality_false_detected_ceiling(quality_report, baseline):
+    ceiling = int(baseline["pooled"]["false_detected_points"]) + 2
+    assert quality_report["pooled"]["false_detected_points"] <= ceiling
+
+
+def test_quality_every_video_alive(quality_report):
+    dead = [
+        report["id"]
+        for report in quality_report["per_video"]
+        if int(report["point_metrics"]["well_classified_points"]) < 1
+    ]
+    assert dead == []


### PR DESCRIPTION
## Summary
- Slow e2e quality suite that runs fixed labeled video windows through the RallyClip CLI and compares exported segment CSVs against ground truth
- Supports swapped model artifacts and release binaries (`RallyClip --cli`, dormant until the desktop release branch lands)
- Ships GT fixtures for 5 labeled match windows, a manifest, a baseline metrics snapshot, and `scripts/eval_quality.py` / `scripts/pick_eval_windows.py` drivers

## Test plan
- Tests are marked `e2e` + `slow` and self-skip unless `RALLYCLIP_EVAL_VIDEO_DIR` points at the source videos, so default CI runs are unaffected
- Run locally: `RALLYCLIP_EVAL_VIDEO_DIR=<videos> pytest tests/test_quality_e2e.py -m "e2e and slow"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)