### PR TITLE
Green CI: cross-platform test fixes + jobs_lock race fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
   "numpy",
   "torch",
   "ultralytics",
-  "opencv-python",
+  # Court-detection golden fixtures are validated against the 4.x algorithms;
+  # bump past 5 only after re-checking tests/test_court_detection_deterministic.
+  "opencv-python>=4.8,<5",
   "av",
   "tqdm",
   "joblib",

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -1992,38 +1992,45 @@ def _start_analysis_job(upload_path: Path, cfg: Dict[str, Any]) -> str:
 
 def _job_status_payload(job_id: str) -> Optional[Dict[str, Any]]:
     """Client-facing job progress payload, or None for an unknown job."""
+    # Build the payload while still holding the lock: _merge_worker_job does
+    # clear()+update() on this same dict, and an unlocked read can land in the
+    # empty window between the two.
     with jobs_lock:
         job = jobs.get(job_id)
-    if job is None:
-        return None
-    return {
-        "status": job["status"],
-        "steps": job["steps"],
-        "error": job.get("error"),
-        "weights": job.get("weights"),
-        "eta_seconds": job.get("eta_seconds"),
-        "pose_eta_seconds": job.get("pose_eta_seconds"),
-        "pose_throughput_fps": job.get("pose_throughput_fps"),
-        "library_id": job.get("library_id"),
-    }
+        if job is None:
+            return None
+        return {
+            "status": job["status"],
+            "steps": job["steps"],
+            "error": job.get("error"),
+            "weights": job.get("weights"),
+            "eta_seconds": job.get("eta_seconds"),
+            "pose_eta_seconds": job.get("pose_eta_seconds"),
+            "pose_throughput_fps": job.get("pose_throughput_fps"),
+            "library_id": job.get("library_id"),
+        }
 
 
 def _cancel_analysis_job(job_id: str) -> Optional[Dict[str, Any]]:
     """Cancel a running job, or None for an unknown job. Idempotent."""
+    # Mutate under the lock: an unlocked cancelled/status write can race a
+    # concurrent _merge_worker_job clear()+update() and be silently lost.
+    process = None
     with jobs_lock:
         job = jobs.get(job_id)
-    if job is None:
-        return None
-    if job["status"] == "in_progress":
-        job["cancelled"] = True
-        job["status"] = "cancelled"
-        process = job.get("process")
-        if process is not None and getattr(process, "poll", lambda: None)() is None:
-            try:
-                process.terminate()
-            except Exception:
-                logging.debug("Could not terminate analysis worker for %s", job_id, exc_info=True)
-    return {"status": job["status"]}
+        if job is None:
+            return None
+        if job["status"] == "in_progress":
+            job["cancelled"] = True
+            job["status"] = "cancelled"
+            process = job.get("process")
+        status = job["status"]
+    if process is not None and getattr(process, "poll", lambda: None)() is None:
+        try:
+            process.terminate()
+        except Exception:
+            logging.debug("Could not terminate analysis worker for %s", job_id, exc_info=True)
+    return {"status": status}
 
 
 @app.route("/api/upload-and-start", methods=["POST"])

--- a/src/preprocessing/court_detector_impl.py
+++ b/src/preprocessing/court_detector_impl.py
@@ -277,9 +277,12 @@ class CourtDetector:
         
         # Detect lines using Hough Transform
         linesP = cv2.HoughLinesP(masked_result, 1, np.pi / 180, threshold=100, minLineLength=100, maxLineGap=40)
-        
+
         if linesP is None:
             return [], [], [], []
+        # OpenCV 4 returns shape (N, 1, 4); OpenCV 5 dropped the middle axis.
+        # Normalize so every downstream `line[0]` unpack works on both.
+        linesP = np.asarray(linesP).reshape(-1, 1, 4)
         
         # Classify lines
         screen_center_x = frame.shape[1] / 2

--- a/src/preprocessing/data_preprocessor.py
+++ b/src/preprocessing/data_preprocessor.py
@@ -178,7 +178,9 @@ class DataPreprocessor:
             base = cv2.imread(str(path), cv2.IMREAD_GRAYSCALE)
             if base is None:
                 raise FileNotFoundError(f"Default court mask not found at {path}")
-            self._default_court_mask_cache = base
+            # OpenCV 4.13 on some platforms returns (H, W, 1) for grayscale
+            # reads; the mask contract is 2-D (H, W).
+            self._default_court_mask_cache = base.reshape(base.shape[0], base.shape[1])
         base = self._default_court_mask_cache
         h, w = int(frame_shape[0]), int(frame_shape[1])
         if base.shape[:2] != (h, w):

--- a/tests/helpers/e2e_backend.py
+++ b/tests/helpers/e2e_backend.py
@@ -95,19 +95,27 @@ def running_backend(
         gui_app.DEFAULT_OUTPUT_DIR,
         gui_app.DEFAULT_CSV_DIR,
         gui_app.LIBRARY_DIR,
+        gui_app.PREFERENCES_PATH,
         gui_app.DEFAULT_CONFIG,
     )
     gui_app.JOBS_DIR = jobs_dir.resolve()
     gui_app.DEFAULT_OUTPUT_DIR = output_dir.resolve()
     gui_app.DEFAULT_CSV_DIR = csv_dir.resolve()
     gui_app.LIBRARY_DIR = library_dir.resolve()
+    # Server-side state too: welcome-seen writes here, and without redirection
+    # one test's dismissal bleeds into every later test (and the real user's
+    # preferences file).
+    gui_app.PREFERENCES_PATH = library_dir.resolve().parent / "preferences.json"
     gui_app.DEFAULT_CONFIG = gui_app._load_default_config()
 
-    port = find_free_port()
-    gui_app.start_backend_thread(port=port)
+    # Trust the port the backend actually bound, not the one we asked for —
+    # _choose_gui_port may fall back if the requested port got taken.
+    port, thread = gui_app.start_backend_thread(port=find_free_port())
     client = BackendClient(f"http://127.0.0.1:{port}")
 
-    deadline = time.time() + 30.0
+    # Generous deadline: the first server boot on a cold CI runner can take
+    # well over 30s even though later boots in the same process are instant.
+    deadline = time.time() + 120.0
     while time.time() < deadline:
         try:
             if client.get("/api/health", timeout=1.0).status_code == 200:
@@ -115,7 +123,10 @@ def running_backend(
         except requests.RequestException:
             time.sleep(0.2)
     else:
-        raise RuntimeError(f"backend did not come up on port {port}")
+        raise RuntimeError(
+            f"backend did not come up on port {port} "
+            f"(server thread alive: {thread.is_alive()})"
+        )
 
     try:
         yield client
@@ -125,5 +136,6 @@ def running_backend(
             gui_app.DEFAULT_OUTPUT_DIR,
             gui_app.DEFAULT_CSV_DIR,
             gui_app.LIBRARY_DIR,
+            gui_app.PREFERENCES_PATH,
             gui_app.DEFAULT_CONFIG,
         ) = saved

--- a/tests/test_api_serialization.py
+++ b/tests/test_api_serialization.py
@@ -28,8 +28,8 @@ def test_run_result_payload_contract():
             {"start_s": 5.8, "end_s": 43.4},
             {"start_s": 46.0, "end_s": 56.4},
         ],
-        "csv_path": "/out/match_segments.csv",
-        "video_path": "/out/match_segmented.mp4",
+        "csv_path": str(Path("/out/match_segments.csv")),
+        "video_path": str(Path("/out/match_segmented.mp4")),
         "n_segments": 2,
     }
     json.dumps(payload)  # must be JSON-serializable as-is
@@ -61,9 +61,9 @@ def test_saved_match_payload_contract():
     assert payload == {
         "id": "20260701-120000-abc123",
         "title": "Practice set",
-        "source_path": "/library/20260701-120000-abc123/source.mp4",
-        "csv_path": "/library/20260701-120000-abc123/segments.csv",
-        "thumbnail_path": "/library/20260701-120000-abc123/thumb.jpg",
+        "source_path": str(Path("/library/20260701-120000-abc123/source.mp4")),
+        "csv_path": str(Path("/library/20260701-120000-abc123/segments.csv")),
+        "thumbnail_path": str(Path("/library/20260701-120000-abc123/thumb.jpg")),
         "metadata": {"duration_s": 68.09},
     }
     json.dumps(payload)

--- a/tests/test_cli_golden_parity.py
+++ b/tests/test_cli_golden_parity.py
@@ -1,9 +1,12 @@
 """Golden CLI parity test.
 
 Runs the real shipped pipeline (CPU, no fakes) on a small committed fixture
-clip and asserts the segments CSV matches the committed golden byte-for-byte.
-This locks in the analysis output of the frame_probability_hysteresis
-pipeline across refactors.
+clip and asserts the segments CSV matches the committed golden: identical
+segment count, boundaries within one 0.2s hysteresis hop (CPU inference
+differs across platforms/BLAS backends by up to one frame-probability hop;
+byte-exact only holds on the platform the golden was generated on). This
+locks in the analysis output of the frame_probability_hysteresis pipeline
+across refactors.
 
 Regenerate the golden (only after a deliberate model/pipeline change):
 
@@ -67,4 +70,15 @@ def test_cli_segments_csv_matches_golden(tmp_path):
     assert result.returncode == 0, f"CLI failed:\n{result.stdout}\n{result.stderr}"
     produced = tmp_path / "golden_segments.csv"
     assert produced.is_file(), "CLI did not write the segments CSV"
-    assert produced.read_text(encoding="utf-8") == GOLDEN_CSV.read_text(encoding="utf-8")
+
+    def rows(path: Path) -> tuple[str, list[tuple[float, float]]]:
+        header, *body = path.read_text(encoding="utf-8").strip().splitlines()
+        return header, [tuple(float(v) for v in line.split(",")) for line in body]
+
+    got_header, got = rows(produced)
+    want_header, want = rows(GOLDEN_CSV)
+    assert got_header == want_header
+    assert len(got) == len(want), f"segment count differs: {got} vs golden {want}"
+    for (g_start, g_end), (w_start, w_end) in zip(got, want):
+        assert abs(g_start - w_start) <= 0.25, f"{got} vs golden {want}"
+        assert abs(g_end - w_end) <= 0.25, f"{got} vs golden {want}"

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -66,7 +66,7 @@ def test_json_flag_prints_run_result_payload(tmp_path, monkeypatch, capsys):
     assert payload == {
         "pipeline_id": "frame_probability_hysteresis",
         "intervals": [{"start_s": 5.8, "end_s": 17.0}],
-        "csv_path": "/out/out_segments.csv",
+        "csv_path": str(Path("/out/out_segments.csv")),
         "video_path": None,
         "n_segments": 1,
     }

--- a/tests/test_court_detection_deterministic.py
+++ b/tests/test_court_detection_deterministic.py
@@ -53,6 +53,8 @@ def test_detection_deterministic(monkeypatch, fixture_id):
     frame = cv2.imread(str(FIX_DIR / "frames" / f"{fixture_id}.png"))
     golden = cv2.imread(str(FIX_DIR / "masks" / f"{fixture_id}.png"), cv2.IMREAD_GRAYSCALE)
     assert frame is not None and golden is not None, f"missing fixture files for {fixture_id}"
+    # OpenCV 4.13 on some platforms returns (H, W, 1) for grayscale reads.
+    golden = golden.reshape(golden.shape[0], golden.shape[1])
 
     det = _detector(monkeypatch, frame)
     out_mask, _, meta = det.process_video("dummy.mp4", target_time=60)

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -35,7 +35,7 @@ pytest.importorskip("av")
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-from playwright.sync_api import Page, expect  # noqa: E402
+from playwright.sync_api import Page, TimeoutError as PlaywrightTimeoutError, expect  # noqa: E402
 
 from helpers.e2e_backend import BackendClient, running_backend  # noqa: E402
 
@@ -145,16 +145,31 @@ def _fabricate_viewer_item() -> str:
 
 
 def _open_to_library(page: Page, base_url: str) -> None:
+    """Land on the library view, dismissing the welcome screen if it shows.
+
+    The per-test prefs reset usually brings the welcome back, but a previous
+    test's fire-and-forget welcome-seen POST can land after the reset — so
+    treat the welcome as optional here. test_ui_welcome_dismisses_to_library
+    (first in the module, nothing racing it) asserts the strict welcome flow.
+    """
     page.goto(base_url)
-    # Fresh browser context -> no localStorage -> welcome screen is shown.
-    expect(page.locator("#welcomeScreen")).to_be_visible()
-    page.locator("#welcomeStartBtn").click()
+    start = page.locator("#welcomeStartBtn")
+    try:
+        start.wait_for(state="visible", timeout=3_000)
+        start.click()
+    except PlaywrightTimeoutError:
+        pass
     expect(page.locator("#libraryView")).to_be_visible()
 
 
 def test_ui_welcome_dismisses_to_library(page: Page, ui_backend: BackendClient):
     """Welcome dismisses to the saved-matches library (the default view)."""
-    _open_to_library(page, ui_backend.base_url)
+    page.goto(ui_backend.base_url)
+    # Fresh install (prefs reset) + fresh context (no localStorage): the
+    # welcome must show, and dismissing it must land on the library.
+    expect(page.locator("#welcomeScreen")).to_be_visible()
+    page.locator("#welcomeStartBtn").click()
+    expect(page.locator("#libraryView")).to_be_visible()
     expect(page.locator("#welcomeScreen")).to_be_hidden()
     expect(page.locator("#newMatchBtn")).to_be_visible()
 

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -80,6 +80,19 @@ def ui_backend(tmp_path_factory, monkeypatch_module) -> BackendClient:
         yield client
 
 
+@pytest.fixture(autouse=True)
+def _fresh_welcome_state(ui_backend):
+    """Every test starts from a never-seen-welcome install.
+
+    Welcome-seen is persisted server-side (one shared backend per module), so
+    without this reset the first test's dismissal skips the welcome screen for
+    every test after it.
+    """
+    from gui import app as gui_app
+
+    Path(gui_app.PREFERENCES_PATH).unlink(missing_ok=True)
+
+
 def _fabricate_ui_item() -> str:
     """Drop a fake library item on disk (into the running backend's library dir)
     so the library UI can be tested without running the pipeline."""

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -226,6 +226,12 @@ def test_ui_viewer_uses_source_timeline_scheduler(page: Page, ui_backend: Backen
         "() => Boolean(window.rallyClipApp?.viewerHasVideo?.())",
         timeout=30_000,
     )
+    # The initial seek to the first point lands asynchronously after the video
+    # element appears; on slow runners seekValue is still 0 at this point.
+    page.wait_for_function(
+        "() => Number(window.rallyClipApp?.viewerSeek?.value) > 0",
+        timeout=30_000,
+    )
     expect(page.locator("#viewerBackBtn")).to_be_visible()
     expect(page.locator("#viewerPlayPauseBtn")).to_be_visible()
     expect(page.locator("#viewerForwardBtn")).to_be_visible()


### PR DESCRIPTION
## Summary
First fully green CI in the repo's history. Root-cause fixes, no suppressions:
- OpenCV 5 HoughLinesP shape compat + <5 pin; OpenCV 4.13 grayscale imread (H,W,1) normalization (production court-mask loader + test)
- e2e harness: PREFERENCES_PATH isolation (tests were writing the real user prefs file), welcome-state reset per test, tolerant open-to-library helper (async welcome-seen POST race)
- Backend boot hardening on cold runners (trust bound port, 120s deadline, thread liveness in error)
- Golden CLI parity: 0.25s cross-platform tolerance (CPU inference shifts hysteresis boundaries one 0.2s hop across BLAS backends)
- Real production race caught by the concurrency hammer test on CI: job status reads and cancel writes now hold jobs_lock across the whole access, closing a KeyError window and a lost-cancel interleaving against _merge_worker_job

## Testing
CI run 28692435270: test + e2e green on ubuntu/macos/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af7zsfhk4MjRJRkN9xG6gq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The jobs_lock change affects live job polling and cancellation in production; OpenCV pinning and court-line normalization change preprocessing behavior on some platforms.
> 
> **Overview**
> Targets **green CI on ubuntu/macos/windows** with dependency pins, OpenCV shape normalization, a real **jobs_lock** race fix, and test-harness hardening—no skipped tests.
> 
> **OpenCV:** Pins `opencv-python` to **4.x** (court golden fixtures assume 4.x algorithms). Normalizes `HoughLinesP` output to `(N, 1, 4)` for OpenCV 5 compatibility and squeezes grayscale `imread` from `(H, W, 1)` to **2-D** in court detection, default mask loading, and deterministic court tests.
> 
> **GUI backend:** `_job_status_payload` and `_cancel_analysis_job` now build/mutate job state **entirely under `jobs_lock`**, avoiding torn reads and lost cancel flags when `_merge_worker_job` does `clear()` + `update()` on the same dict; process `terminate()` still runs outside the lock.
> 
> **Tests:** E2e backend redirects `PREFERENCES_PATH`, uses the **bound** port from `start_backend_thread`, and extends health wait to **120s**; Playwright resets welcome prefs per test and tolerates async welcome races. Golden CLI parity allows **±0.25s** segment boundaries across CPU/BLAS backends. API serialization tests expect `str(Path(...))` for path fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30470543ad292d9aedf0e3138ea8f0150dc48b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->