### PR TITLE
fix: store frozen-app user data in the OS app-data dir

### DIFF
--- a/RallyClip.spec
+++ b/RallyClip.spec
@@ -21,7 +21,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=['PyQt5', 'PyQt6', 'PySide2', 'openvino', 'torch', 'torchvision', 'ultralytics', 'PySide6', 'shiboken6'],
+    excludes=['PyQt5', 'PyQt6', 'PySide2', 'openvino', 'torch', 'torchvision', 'ultralytics', 'PySide6', 'shiboken6', 'tensorflow', 'keras', 'tf_keras', 'tensorflow_hub', 'tensorboard'],
     noarchive=False,
     optimize=0,
 )

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -87,10 +87,25 @@ STATIC_DIR = resolve_frontend_dir()
 
 
 def _frozen_data_root() -> Optional[Path]:
-    """In packaged builds, keep user data out of the bundle and the CWD."""
-    if getattr(sys, "frozen", False):
-        return (Path.home() / "RallyClip").resolve()
-    return None
+    """In packaged builds, keep user data in the OS per-user app-data dir."""
+    if not getattr(sys, "frozen", False):
+        return None
+    if sys.platform == "darwin":
+        root = Path.home() / "Library" / "Application Support" / "RallyClip"
+    elif os.name == "nt":
+        root = Path(os.environ.get("APPDATA") or (Path.home() / "AppData" / "Roaming")) / "RallyClip"
+    else:
+        root = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "RallyClip"
+    root = root.resolve()
+    legacy = (Path.home() / "RallyClip").resolve()
+    if not root.exists() and legacy.is_dir():
+        # v0.1.0 stored data at ~/RallyClip; move it once instead of orphaning it.
+        try:
+            root.parent.mkdir(parents=True, exist_ok=True)
+            legacy.rename(root)
+        except OSError:
+            pass
+    return root
 
 
 def _default_jobs_dir() -> Path:

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -102,7 +102,9 @@ def _frozen_data_root() -> Optional[Path]:
         # v0.1.0 stored data at ~/RallyClip; move it once instead of orphaning it.
         try:
             root.parent.mkdir(parents=True, exist_ok=True)
-            legacy.rename(root)
+            # shutil.move falls back to copy+delete when the app-data dir
+            # lives on a different filesystem (rename would raise EXDEV).
+            shutil.move(str(legacy), str(root))
         except OSError:
             pass
     return root

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -92,7 +92,7 @@ def _frozen_data_root() -> Optional[Path]:
         return None
     if sys.platform == "darwin":
         root = Path.home() / "Library" / "Application Support" / "RallyClip"
-    elif os.name == "nt":
+    elif sys.platform == "win32":
         root = Path(os.environ.get("APPDATA") or (Path.home() / "AppData" / "Roaming")) / "RallyClip"
     else:
         root = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "RallyClip"

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -721,6 +721,7 @@ def test_frozen_data_root_uses_platform_app_data_dir(tmp_path, monkeypatch):
     ).resolve()
 
     monkeypatch.setattr(real_sys, "platform", "linux")
+    monkeypatch.setattr(os, "name", "posix")
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     assert gui_app._frozen_data_root() == (
         tmp_path / ".local" / "share" / "RallyClip"

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -720,8 +720,9 @@ def test_frozen_data_root_uses_platform_app_data_dir(tmp_path, monkeypatch):
         tmp_path / "Library" / "Application Support" / "RallyClip"
     ).resolve()
 
+    # Only sys.platform is patched: pathlib picks WindowsPath/PosixPath from
+    # os.name at instantiation, so patching os.name breaks Path() on Windows.
     monkeypatch.setattr(real_sys, "platform", "linux")
-    monkeypatch.setattr(os, "name", "posix")
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     assert gui_app._frozen_data_root() == (
         tmp_path / ".local" / "share" / "RallyClip"

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -699,3 +699,55 @@ def test_library_video_export_generates_cut_on_demand(tmp_path, monkeypatch):
     assert response.data == b"cut video"
     assert calls == [(str(source), [(1.0, 3.0), (4.0, 5.0)], str(item_dir / "export.mp4"))]
     assert (item_dir / "export.mp4").read_bytes() == b"cut video"
+
+
+def test_frozen_data_root_is_none_when_not_frozen():
+    import gui.app as gui_app
+
+    assert gui_app._frozen_data_root() is None
+
+
+def test_frozen_data_root_uses_platform_app_data_dir(tmp_path, monkeypatch):
+    import sys as real_sys
+
+    import gui.app as gui_app
+
+    monkeypatch.setattr(real_sys, "frozen", True, raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    monkeypatch.setattr(real_sys, "platform", "darwin")
+    assert gui_app._frozen_data_root() == (
+        tmp_path / "Library" / "Application Support" / "RallyClip"
+    ).resolve()
+
+    monkeypatch.setattr(real_sys, "platform", "linux")
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    assert gui_app._frozen_data_root() == (
+        tmp_path / ".local" / "share" / "RallyClip"
+    ).resolve()
+
+
+def test_frozen_data_root_migrates_legacy_home_dir(tmp_path, monkeypatch):
+    import sys as real_sys
+
+    import gui.app as gui_app
+
+    monkeypatch.setattr(real_sys, "frozen", True, raising=False)
+    monkeypatch.setattr(real_sys, "platform", "darwin")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    legacy = tmp_path / "RallyClip"
+    (legacy / "library").mkdir(parents=True)
+    (legacy / "preferences.json").write_text("{}", encoding="utf-8")
+
+    root = gui_app._frozen_data_root()
+
+    assert root == (tmp_path / "Library" / "Application Support" / "RallyClip").resolve()
+    assert not legacy.exists()
+    assert (root / "library").is_dir()
+    assert (root / "preferences.json").read_text(encoding="utf-8") == "{}"
+
+    # Second call is a no-op once the new root exists.
+    (tmp_path / "RallyClip").mkdir()
+    assert gui_app._frozen_data_root() == root
+    assert (tmp_path / "RallyClip").is_dir()


### PR DESCRIPTION
The packaged app dumped its data at ~/RallyClip in the user's home folder. It now uses the platform app-data location — ~/Library/Application Support/RallyClip on macOS, %APPDATA%/RallyClip on Windows, XDG data dir on Linux — with a one-time rename migration from the legacy ~/RallyClip so existing installs keep their library.

Single-point change in `gui.app._frozen_data_root()` (jobs/output/csv/library/preferences/models/logs all derive from it) plus unit tests for the platform paths and the migration.

Fast suite: 205 passed, 1 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> One-time data migration on upgrade can fail silently (OSError swallowed), leaving users on an empty app-data dir while legacy data remains in ~/RallyClip; path change affects all persistent frozen-app state.
> 
> **Overview**
> **Packaged (frozen) builds** no longer write user data to `~/RallyClip`. `_frozen_data_root()` now resolves **macOS** `~/Library/Application Support/RallyClip`, **Windows** `%APPDATA%/RallyClip`, and **Linux** XDG data (or `~/.local/share/RallyClip`). Jobs, outputs, CSVs, library, preferences, models cache, and logs all flow from that root as before.
> 
> On first launch after upgrade, if the new root is missing but legacy `~/RallyClip` exists, the app **moves** the whole folder into the app-data location (with `shutil.move` so cross-filesystem installs work); failures are ignored and a second call does not re-migrate.
> 
> **PyInstaller** `RallyClip.spec` adds excludes for `tensorflow`, `keras`, `tf_keras`, `tensorflow_hub`, and `tensorboard` to keep the torch-free bundle lean.
> 
> **Tests** cover non-frozen `None`, darwin/linux paths, and legacy migration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53da3811046b4230332cc9f8e1fa0d45c4071ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->