### PR TITLE
fix: stream saved-match source directly in the viewer (stuck-at-8s bug)

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import mimetypes
 import os
 import re
 import shutil
@@ -2448,6 +2449,22 @@ def library_video_preview_window(item_id: str):
     except Exception as exc:
         logging.exception("Could not prepare preview window %s", item_id)
         return jsonify({"error": f"Could not prepare preview window: {exc}"}), 500
+
+
+@app.route("/api/library/<item_id>/source", methods=["GET"])
+def library_source(item_id: str):
+    """Serve the saved match source with Range support for direct playback.
+
+    The system webview (WKWebView/WebView2) decodes H.264/HEVC natively, so
+    the viewer streams this instead of waiting on WebM preview-window
+    transcodes; the window pipeline stays as the fallback for engines that
+    cannot play the source codec.
+    """
+    path = _resolve_library_source(item_id)
+    if path is None:
+        return jsonify({"error": "Video not available"}), 404
+    mimetype = mimetypes.guess_type(path.name)[0] or "video/mp4"
+    return send_file(str(path), mimetype=mimetype, conditional=True)
 
 
 @app.route("/api/library/<item_id>/playback", methods=["GET"])

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -49,6 +49,8 @@ class RallyClipApp {
         this.sourceDuration = 0;
         this.previewRequestSeq = 0;
         this.previewLoadInProgress = false;
+        this.directPlayback = false;
+        this.directProbeInProgress = false;
         this.previewSpinnerTimeout = null;
         this.viewerControlsHideTimeout = null;
         this.welcomeTypeTimers = [];
@@ -495,6 +497,7 @@ class RallyClipApp {
             this.clearPreviewPoll();
             this.resetMsePreview();
             this.resetViewerVideos();
+            this.directPlayback = false;
             this.viewingItemId = null;
             this.pointIntervals = [];
             this.lastViewerTime = null;
@@ -769,6 +772,7 @@ class RallyClipApp {
         this.viewerTitle.textContent = item.name || "Match";
         this.viewerMeta.textContent = item.metaText || this.cardMeta(item);
         this.viewerCsvBtn.hidden = !item.has_csv;
+        this.directPlayback = false;
         this.resetViewerVideos();
         this.updateViewerControls();
         this.showPreviewLoading();
@@ -776,7 +780,66 @@ class RallyClipApp {
         this.showViewerControls();
         await this.loadPlaybackManifest(item.id);
         const start = this.pointIntervals.length ? this.pointIntervals[0].start : 0;
+        if (await this.tryDirectSourcePlayback(start, true)) return;
         this.seekViewerToSourceTime(start, true);
+    }
+
+    tryDirectSourcePlayback(sourceTime, autoplay = true) {
+        // Stream the original file (Range requests, native codec decode) and
+        // model it as one full-length window so the existing source-time math
+        // (seeks, point skips, timeline) applies unchanged. Resolves false when
+        // the engine cannot play the codec; callers then use preview windows.
+        if (!this.viewingItemId) return Promise.resolve(false);
+        const itemId = this.viewingItemId;
+        const video = this.matchVideo;
+        const sourceUrl = `/api/library/${itemId}/source`;
+        this.directPlayback = false;
+        this.directProbeInProgress = true;
+        return new Promise((resolve) => {
+            let settled = false;
+            let timer = null;
+            const settle = (ok) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                video.removeEventListener("canplay", onReady);
+                video.removeEventListener("error", onError);
+                this.directProbeInProgress = false;
+                resolve(ok);
+            };
+            const onReady = () => {
+                if (this.viewingItemId !== itemId || video !== this.matchVideo) {
+                    settle(false);
+                    return;
+                }
+                if (!(this.sourceDuration > 0) && Number.isFinite(video.duration) && video.duration > 0) {
+                    this.sourceDuration = video.duration;
+                    this.configureViewerTimeline(this.sourceDuration);
+                }
+                video.dataset.windowStart = "0";
+                video.dataset.windowDuration = String(this.sourceDuration > 0 ? this.sourceDuration : video.duration || 0);
+                this.directPlayback = true;
+                const target = this.clampViewerSourceTime(sourceTime);
+                video.currentTime = target;
+                this.lastViewerTime = target;
+                this.updateViewerTimeline(target);
+                this.hidePreviewLoading();
+                this.updateViewerControls();
+                if (autoplay) this.startViewerPlayback();
+                settle(true);
+            };
+            const onError = () => {
+                console.warn("Direct source playback unavailable; falling back to preview windows", video.error);
+                this.clearVideoElement(video);
+                settle(false);
+            };
+            timer = setTimeout(onError, 10000);
+            video.addEventListener("canplay", onReady);
+            video.addEventListener("error", onError);
+            video.src = sourceUrl;
+            video.dataset.previewUrl = sourceUrl;
+            video.load();
+        });
     }
 
     clearPreviewPoll() {
@@ -1569,7 +1632,7 @@ class RallyClipApp {
     }
 
     prefetchForPlaybackSchedule(sourceTime) {
-        if (!this.viewingItemId) return;
+        if (!this.viewingItemId || this.directPlayback) return;
         this.trimPrefetchedWindowKeys(sourceTime);
         this.getSchedulerPrefetchStarts(sourceTime).forEach((start) => this.prefetchPreviewWindow(start));
     }
@@ -1925,6 +1988,13 @@ class RallyClipApp {
             this.seekMseViewerToSourceTime(target, autoplay);
             return;
         }
+        if (this.directPlayback && this.matchVideo.src) {
+            this.matchVideo.currentTime = target;
+            this.lastViewerTime = target;
+            this.updateViewerTimeline(target);
+            if (autoplay) this.startViewerPlayback();
+            return;
+        }
         const windowStart = this.videoWindowStart(this.matchVideo);
         const windowEnd = this.videoWindowEnd(this.matchVideo);
         if (this.matchVideo.src && target >= windowStart && target < windowEnd - 0.15) {
@@ -1962,9 +2032,19 @@ class RallyClipApp {
     }
 
     handleViewerVideoError() {
+        if (this.directProbeInProgress) return;
         if (!this.matchVideo.src || !this.matchVideo.error) return;
         if (this.mseActive) {
             this.fallbackFromMse(this.getViewerSourceTime(), !this.matchVideo.paused, this.matchVideo.error);
+            return;
+        }
+        if (this.directPlayback) {
+            console.warn("Direct source playback failed mid-stream; falling back to preview windows", this.matchVideo.error);
+            const target = this.lastViewerTime ?? this.getViewerSourceTime();
+            const wasPlaying = !this.matchVideo.paused;
+            this.directPlayback = false;
+            this.clearVideoElement(this.matchVideo);
+            this.loadPreviewWindowAt(target, wasPlaying);
             return;
         }
         this.showToast("Could not play this video in the viewer.", "error");
@@ -2033,7 +2113,7 @@ class RallyClipApp {
     }
 
     continueToNextPreviewWindow(options = {}) {
-        if (!this.viewingItemId || this.pendingPreviewTransition) return;
+        if (!this.viewingItemId || this.pendingPreviewTransition || this.directPlayback) return;
         const sourceTime = this.videoWindowEnd(this.matchVideo);
         if (!this.activePlaybackSegment) this.setPlaybackSegmentForSourceTime(sourceTime);
         const segmentEnd = Number(this.activePlaybackSegment?.end);

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -51,6 +51,7 @@ class RallyClipApp {
         this.previewLoadInProgress = false;
         this.directPlayback = false;
         this.directProbeInProgress = false;
+        this.directProbeSeq = 0;
         this.previewSpinnerTimeout = null;
         this.viewerControlsHideTimeout = null;
         this.welcomeTypeTimers = [];
@@ -779,8 +780,12 @@ class RallyClipApp {
         this.showView("viewer");
         this.showViewerControls();
         await this.loadPlaybackManifest(item.id);
+        if (this.viewingItemId !== item.id) return;
         const start = this.pointIntervals.length ? this.pointIntervals[0].start : 0;
         if (await this.tryDirectSourcePlayback(start, true)) return;
+        // The probe can resolve false long after the user opened another match
+        // or left the viewer; don't drive the fallback for a stale item.
+        if (this.viewingItemId !== item.id) return;
         this.seekViewerToSourceTime(start, true);
     }
 
@@ -795,6 +800,11 @@ class RallyClipApp {
         const sourceUrl = `/api/library/${itemId}/source`;
         this.directPlayback = false;
         this.directProbeInProgress = true;
+        // Sequence number invalidates this probe's callbacks (canplay/error/10s
+        // timer) the moment a newer probe starts: a stale closure must not clear
+        // the shared in-progress flag, touch the video element another probe now
+        // owns, or trigger the fallback path for the wrong match.
+        const probeId = ++this.directProbeSeq;
         return new Promise((resolve) => {
             let settled = false;
             let timer = null;
@@ -804,11 +814,13 @@ class RallyClipApp {
                 clearTimeout(timer);
                 video.removeEventListener("canplay", onReady);
                 video.removeEventListener("error", onError);
-                this.directProbeInProgress = false;
+                if (this.directProbeSeq === probeId) this.directProbeInProgress = false;
                 resolve(ok);
             };
+            const probeIsStale = () =>
+                this.directProbeSeq !== probeId || this.viewingItemId !== itemId || video !== this.matchVideo;
             const onReady = () => {
-                if (this.viewingItemId !== itemId || video !== this.matchVideo) {
+                if (probeIsStale()) {
                     settle(false);
                     return;
                 }
@@ -829,6 +841,10 @@ class RallyClipApp {
                 settle(true);
             };
             const onError = () => {
+                if (probeIsStale()) {
+                    settle(false);
+                    return;
+                }
                 console.warn("Direct source playback unavailable; falling back to preview windows", video.error);
                 this.clearVideoElement(video);
                 settle(false);

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -232,8 +232,10 @@ def test_ui_viewer_uses_source_timeline_scheduler(page: Page, ui_backend: Backen
     page.locator(f'.lib-card[data-id="{item_id}"]').click()
     expect(page.locator("#viewerView")).to_be_visible()
     expect(page.locator("#viewerTimeline")).to_be_visible(timeout=30_000)
+    # Direct source playback engages when the engine can decode the clip;
+    # otherwise the viewer falls back to WebM preview windows.
     page.wait_for_function(
-        "() => { const src = window.rallyClipApp?.matchVideo?.src || ''; return src.includes('/preview/window'); }",
+        "() => { const src = window.rallyClipApp?.matchVideo?.src || ''; return src.includes('/preview/window') || src.includes('/source'); }",
         timeout=30_000,
     )
     page.wait_for_function(
@@ -425,6 +427,7 @@ def test_ui_viewer_uses_source_timeline_scheduler(page: Page, ui_backend: Backen
                 preserveSegment: Boolean(options?.preserveSegment),
             });
             app.viewingItemId = "match-ready";
+            app.directPlayback = false;
             app.sourceDuration = 120;
             app.pointIntervals = [{ start: 1, end: 2 }, { start: 4, end: 5 }, { start: 10, end: 12 }];
             app.activePlaybackSegment = { kind: "gap", start: 2.5, end: 5, pointIndex: 1, nextPointIndex: 2 };

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -699,3 +699,27 @@ def test_library_video_export_generates_cut_on_demand(tmp_path, monkeypatch):
     assert response.data == b"cut video"
     assert calls == [(str(source), [(1.0, 3.0), (4.0, 5.0)], str(item_dir / "export.mp4"))]
     assert (item_dir / "export.mp4").read_bytes() == b"cut video"
+
+
+def test_library_source_streams_with_range_support(tmp_path, monkeypatch):
+    from gui import app as gui_app
+
+    library = tmp_path / "library"
+    item_dir = library / "match-1"
+    item_dir.mkdir(parents=True)
+    (item_dir / "source.mp4").write_bytes(b"0123456789abcdef")
+    (item_dir / "meta.json").write_text('{"name": "Match 1"}', encoding="utf-8")
+    monkeypatch.setattr(gui_app, "LIBRARY_DIR", library)
+    client = gui_app.app.test_client()
+
+    full = client.get("/api/library/match-1/source")
+    assert full.status_code == 200
+    assert full.data == b"0123456789abcdef"
+    assert full.mimetype == "video/mp4"
+
+    partial = client.get("/api/library/match-1/source", headers={"Range": "bytes=4-7"})
+    assert partial.status_code == 206
+    assert partial.data == b"4567"
+    assert partial.headers.get("Content-Range") == "bytes 4-7/16"
+
+    assert client.get("/api/library/no-such-item/source").status_code == 404

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -753,3 +753,25 @@ def test_frozen_data_root_migrates_legacy_home_dir(tmp_path, monkeypatch):
     (tmp_path / "RallyClip").mkdir()
     assert gui_app._frozen_data_root() == root
     assert (tmp_path / "RallyClip").is_dir()
+def test_library_source_streams_with_range_support(tmp_path, monkeypatch):
+    from gui import app as gui_app
+
+    library = tmp_path / "library"
+    item_dir = library / "match-1"
+    item_dir.mkdir(parents=True)
+    (item_dir / "source.mp4").write_bytes(b"0123456789abcdef")
+    (item_dir / "meta.json").write_text('{"name": "Match 1"}', encoding="utf-8")
+    monkeypatch.setattr(gui_app, "LIBRARY_DIR", library)
+    client = gui_app.app.test_client()
+
+    full = client.get("/api/library/match-1/source")
+    assert full.status_code == 200
+    assert full.data == b"0123456789abcdef"
+    assert full.mimetype == "video/mp4"
+
+    partial = client.get("/api/library/match-1/source", headers={"Range": "bytes=4-7"})
+    assert partial.status_code == 206
+    assert partial.data == b"4567"
+    assert partial.headers.get("Content-Range") == "bytes 4-7/16"
+
+    assert client.get("/api/library/no-such-item/source").status_code == 404


### PR DESCRIPTION
## Bug
Viewer playback stalled at the first 8 seconds and point skips hung. Root cause (reproduced with a driven WebKit session): the viewer's only playback path was the QtWebEngine-era pipeline — 8s VP8/WebM preview windows transcoded on demand — and each window takes ~2.5x realtime to encode, so playback waits 10-20s at every window boundary. It was never a deadlock; generation just can't outrun playback.

## Fix
The system webview (WKWebView/WebView2) decodes H.264/HEVC natively, so the viewer now streams the original file via a new `/api/library/<id>/source` route (Flask `send_file(conditional=True)`, Range/206). The file is modeled as one full-length window so the existing source-time scheduler — seeks, point skips, timeline — applies unchanged. The preview-window pipeline stays as automatic fallback when the engine can't play the source codec (probe error/timeout at open, plus mid-stream error fallback).

## Verification
- Driven WebKit session on a real analyzed match: continuous playback through old window boundaries, auto-skip across all 6 points, zero preview-window requests or transcodes
- New unit test: `/source` full + Range (206, Content-Range) + 404
- Fast suite 203 passed, 1 skipped; `test_gui_playwright.py` 6/6 in Chromium (direct + fallback paths both exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af7zsfhk4MjRJRkN9xG6gq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core viewer playback and a new library streaming endpoint (Range/conditional responses); fallback to preview windows limits blast radius if direct decode fails.
> 
> **Overview**
> Fixes viewer playback that **stalled at ~8s** because the only path was on-demand **8s WebM preview windows** that transcode slower than realtime.
> 
> Adds **`GET /api/library/<id>/source`** to serve the saved **`source.mp4`** with **`send_file(..., conditional=True)`** (HTTP **206** / **Range**) so WKWebView/WebView2 can decode H.264/HEVC natively. On open, the viewer **probes** direct playback via **`tryDirectSourcePlayback`** (stale-probe guards, 10s timeout); on success it treats the file as one full-length window so **seeks, timeline, and point skips** stay unchanged. **Preview-window prefetch and chunk rollovers are skipped** in direct mode; **probe errors** and **mid-stream failures** fall back to the existing WebM window pipeline.
> 
> Tests cover **`/source`** full + partial Range + 404, and Playwright accepts **`/source`** or **`/preview/window`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be91ce251b5c05496181d7e080a85bca433d0b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->