### PR TITLE
feat: non-destructive segment edit mode (trim/add/delete points)

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -41,8 +41,8 @@ except ImportError as exc:  # pragma: no cover - handled at runtime
 from runtime.assets import candidate_roots, resolve_asset
 from runtime.defaults import build_gui_defaults
 from runtime.paths import resolve_frontend_dir
-from rallyclip_core.intervals import read_point_intervals
-from rallyclip_core.library import SavedMatchStore, new_item_id
+from rallyclip_core.intervals import read_point_intervals, write_point_intervals
+from rallyclip_core.library import EDITED_SEGMENTS_FILENAME, SavedMatchStore, new_item_id
 from rallyclip_core.playback import build_playback_manifest, playback_manifest_payload
 
 JobDict = Dict[str, Any]
@@ -2117,6 +2117,11 @@ def _resolve_library_source(item_id: str) -> Optional[Path]:
     return _library_store().resolve_source(item_id)
 
 
+def _resolve_library_segments(item_id: str) -> Optional[Path]:
+    """Effective point-times CSV: user edits win over the model output."""
+    return _library_store().resolve_segments(item_id)
+
+
 def _read_library_meta(item_dir: Path) -> Dict[str, Any]:
     return _library_store().read_meta(item_dir)
 
@@ -2157,9 +2162,9 @@ def native_playback_descriptor(item_id: str) -> Dict[str, Any]:
     source_path = _resolve_library_source(item_id)
     if source_path is None:
         raise FileNotFoundError("Video not available")
-    csv_path = item_dir / "segments.csv"
+    csv_path = _resolve_library_segments(item_id)
     meta = _read_library_meta(item_dir)
-    intervals = _sorted_point_intervals(csv_path if csv_path.exists() else None)
+    intervals = _sorted_point_intervals(csv_path)
     try:
         source_duration = float(meta.get("duration_s") or 0.0)
     except (TypeError, ValueError):
@@ -2182,9 +2187,9 @@ def native_playback_descriptor(item_id: str) -> Dict[str, Any]:
         "source_duration_s": manifest_payload["source_duration_s"],
         "point_intervals": manifest_payload["point_intervals"],
         "point_duration_s": manifest_payload["point_duration_s"],
-        "has_csv": csv_path.exists(),
+        "has_csv": csv_path is not None,
         "has_export": (item_dir / "export.mp4").exists(),
-        "csv_url": f"/api/library/{item_id}/csv" if csv_path.exists() else None,
+        "csv_url": f"/api/library/{item_id}/csv" if csv_path is not None else None,
         "export_url": f"/api/library/{item_id}/video",
         "proxy": _native_playback_proxy_state(source_path, proxy_path),
     }
@@ -2264,7 +2269,7 @@ def ensure_native_playback_proxy(item_id: str) -> Dict[str, Any]:
 
 def _library_playback_manifest_payload(item_id: str) -> Dict[str, Any]:
     source_path = _resolve_library_source(item_id)
-    csv_path = _resolve_library_file(item_id, "segments.csv")
+    csv_path = _resolve_library_segments(item_id)
     if source_path is None:
         raise FileNotFoundError("Video not available")
     if csv_path is None:
@@ -2311,7 +2316,7 @@ def _export_library_video(item_id: str) -> Path:
     source_path = _resolve_library_source(item_id)
     if source_path is None:
         raise FileNotFoundError("Video not available")
-    csv_path = _resolve_library_file(item_id, "segments.csv")
+    csv_path = _resolve_library_segments(item_id)
     if csv_path is None:
         # Legacy items may only have an already-cut video.mp4.
         if source_path.name == "video.mp4":
@@ -2495,26 +2500,101 @@ def library_playback(item_id: str):
     return jsonify(payload), 200
 
 
+def _segments_payload(item_id: str, intervals: list[tuple[float, float]]) -> Dict[str, Any]:
+    return {
+        "segments": [{"start": start, "end": end} for start, end in intervals],
+        "point_duration_s": round(sum(end - start for start, end in intervals), 3),
+        "edited": _library_store().has_edited_segments(item_id),
+    }
+
+
+def _parse_segments_request(payload: Any) -> list[tuple[float, float]]:
+    """Validate an edited-segments body into sorted, non-overlapping intervals."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("segments"), list):
+        raise ValueError("Body must be a JSON object with a 'segments' list")
+    raw = payload["segments"]
+    if len(raw) > 2000:
+        raise ValueError("Too many segments")
+    intervals: list[tuple[float, float]] = []
+    for entry in raw:
+        try:
+            start = float(entry["start"])
+            end = float(entry["end"])
+        except (TypeError, KeyError, ValueError) as exc:
+            raise ValueError("Each segment needs numeric 'start' and 'end'") from exc
+        if not (math.isfinite(start) and math.isfinite(end)):
+            raise ValueError("Segment times must be finite")
+        if start < 0 or end <= start:
+            raise ValueError("Each segment needs 0 <= start < end")
+        intervals.append((round(start, 3), round(end, 3)))
+    intervals.sort()
+    for (_, prev_end), (next_start, _) in zip(intervals, intervals[1:]):
+        if next_start < prev_end:
+            raise ValueError("Segments must not overlap")
+    return intervals
+
+
+def _invalidate_library_export(item_id: str) -> None:
+    # export.mp4 was cut from the previous point times; drop it so the next
+    # download re-exports from the effective CSV.
+    with _export_lock(item_id):
+        (_library_item_dir(item_id) / "export.mp4").unlink(missing_ok=True)
+
+
 @app.route("/api/library/<item_id>/segments", methods=["GET"])
 def library_segments(item_id: str):
-    path = _resolve_library_file(item_id, "segments.csv")
+    path = _resolve_library_segments(item_id)
     if path is None:
         return jsonify({"error": "CSV not available"}), 404
     try:
         intervals = _sorted_point_intervals(path)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
-    return jsonify(
-        {
-            "segments": [{"start": start, "end": end} for start, end in intervals],
-            "point_duration_s": round(sum(end - start for start, end in intervals), 3),
-        }
-    ), 200
+    return jsonify(_segments_payload(item_id, intervals)), 200
+
+
+@app.route("/api/library/<item_id>/segments", methods=["PUT"])
+def library_segments_update(item_id: str):
+    """Save user-edited point times to segments_edited.csv.
+
+    The model-produced segments.csv is never touched, so edits are always
+    reversible via the reset endpoint.
+    """
+    if _resolve_library_segments(item_id) is None:
+        return jsonify({"error": "CSV not available"}), 404
+    try:
+        intervals = _parse_segments_request(request.get_json(silent=True))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    write_point_intervals(_library_item_dir(item_id) / EDITED_SEGMENTS_FILENAME, intervals)
+    _invalidate_library_export(item_id)
+    return jsonify(_segments_payload(item_id, intervals)), 200
+
+
+@app.route("/api/library/<item_id>/segments/edits", methods=["DELETE"])
+def library_segments_reset(item_id: str):
+    """Reset to the original model output by discarding segments_edited.csv."""
+    try:
+        item_dir = _library_item_dir(item_id)
+    except ValueError:
+        return jsonify({"error": "Invalid id"}), 400
+    edited = item_dir / EDITED_SEGMENTS_FILENAME
+    if edited.exists():
+        edited.unlink(missing_ok=True)
+        _invalidate_library_export(item_id)
+    original = _resolve_library_file(item_id, "segments.csv")
+    if original is None:
+        return jsonify({"error": "CSV not available"}), 404
+    try:
+        intervals = _sorted_point_intervals(original)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(_segments_payload(item_id, intervals)), 200
 
 
 @app.route("/api/library/<item_id>/csv", methods=["GET"])
 def library_csv(item_id: str):
-    path = _resolve_library_file(item_id, "segments.csv")
+    path = _resolve_library_segments(item_id)
     if path is None:
         return jsonify({"error": "CSV not available"}), 404
     return send_file(str(path), as_attachment=True, download_name=f"{item_id}_segments.csv")

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -2566,7 +2566,13 @@ def library_segments_update(item_id: str):
         intervals = _parse_segments_request(request.get_json(silent=True))
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
-    write_point_intervals(_library_item_dir(item_id) / EDITED_SEGMENTS_FILENAME, intervals)
+    try:
+        write_point_intervals(_library_item_dir(item_id) / EDITED_SEGMENTS_FILENAME, intervals)
+    except OSError as exc:
+        # Windows refuses to replace a CSV that is open elsewhere (e.g. a
+        # download still streaming it).
+        logging.warning("Could not save edited segments for %s", item_id, exc_info=True)
+        return jsonify({"error": f"Could not save edited points: {exc}"}), 503
     _invalidate_library_export(item_id)
     return jsonify(_segments_payload(item_id, intervals)), 200
 
@@ -2574,21 +2580,24 @@ def library_segments_update(item_id: str):
 @app.route("/api/library/<item_id>/segments/edits", methods=["DELETE"])
 def library_segments_reset(item_id: str):
     """Reset to the original model output by discarding segments_edited.csv."""
-    try:
-        item_dir = _library_item_dir(item_id)
-    except ValueError:
-        return jsonify({"error": "Invalid id"}), 400
-    edited = item_dir / EDITED_SEGMENTS_FILENAME
-    if edited.exists():
-        edited.unlink(missing_ok=True)
-        _invalidate_library_export(item_id)
     original = _resolve_library_file(item_id, "segments.csv")
     if original is None:
+        # Never delete the edited copy unless the original is there to fall
+        # back to; for legacy items it may be the only point data left.
         return jsonify({"error": "CSV not available"}), 404
     try:
         intervals = _sorted_point_intervals(original)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
+    edited = _library_item_dir(item_id) / EDITED_SEGMENTS_FILENAME
+    if edited.exists():
+        try:
+            edited.unlink()
+        except OSError as exc:
+            # Windows refuses to delete a CSV that is open elsewhere.
+            logging.warning("Could not delete edited segments for %s", item_id, exc_info=True)
+            return jsonify({"error": f"Could not reset points: {exc}"}), 503
+        _invalidate_library_export(item_id)
     return jsonify(_segments_payload(item_id, intervals)), 200
 
 

--- a/src/gui/frontend/index.html
+++ b/src/gui/frontend/index.html
@@ -44,6 +44,7 @@
                         <p id="viewerMeta"></p>
                     </div>
                     <div class="viewer-actions">
+                        <button type="button" class="btn btn-secondary" id="viewerEditBtn" hidden>Edit points</button>
                         <button type="button" class="btn btn-secondary" id="viewerCsvBtn" hidden>CSV</button>
                         <button type="button" class="btn btn-primary" id="viewerExportBtn">Export video</button>
                     </div>
@@ -58,6 +59,7 @@
                                 <div class="viewer-buffer-track" id="viewerBufferTrack" aria-hidden="true"></div>
                                 <div class="viewer-point-track" id="viewerPointTrack" aria-hidden="true"></div>
                                 <input type="range" id="viewerSeek" min="0" max="0" step="0.1" value="0" aria-label="Match timeline">
+                                <div class="viewer-edit-track" id="viewerEditTrack" hidden></div>
                             </div>
                             <div class="viewer-control-row">
                                 <div class="viewer-left-controls">
@@ -69,6 +71,15 @@
                                     </div>
                                 </div>
                                 <button type="button" class="viewer-control-btn viewer-fullscreen-btn" id="viewerFullscreenBtn" aria-label="Enter fullscreen">⛶</button>
+                            </div>
+                            <div class="viewer-edit-bar" id="viewerEditBar" hidden>
+                                <span class="viewer-edit-hint" id="viewerEditHint">Tap a point, then drag its ends to trim.</span>
+                                <div class="viewer-edit-actions">
+                                    <button type="button" class="btn btn-secondary btn-small" id="editAddPointBtn">Add point</button>
+                                    <button type="button" class="btn btn-secondary btn-small" id="editDeletePointBtn" disabled>Delete point</button>
+                                    <button type="button" class="btn btn-ghost btn-small" id="editResetBtn" disabled>Reset to original</button>
+                                    <button type="button" class="btn btn-primary btn-small" id="editDoneBtn">Done</button>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -52,6 +52,14 @@ class RallyClipApp {
         this.directPlayback = false;
         this.directProbeInProgress = false;
         this.directProbeSeq = 0;
+        this.editMode = false;
+        this.editSelectedIndex = -1;
+        this.editDrag = null;
+        this.editScrubPending = null;
+        this.editSaveChain = Promise.resolve();
+        this.segmentsEdited = false;
+        this.minPointSeconds = 0.5;
+        this.addPointSeconds = 8;
         this.previewSpinnerTimeout = null;
         this.viewerControlsHideTimeout = null;
         this.welcomeTypeTimers = [];
@@ -139,6 +147,14 @@ class RallyClipApp {
         this.viewerDuration = document.getElementById("viewerDuration");
         this.viewerExportBtn = document.getElementById("viewerExportBtn");
         this.viewerCsvBtn = document.getElementById("viewerCsvBtn");
+        this.viewerEditBtn = document.getElementById("viewerEditBtn");
+        this.viewerEditTrack = document.getElementById("viewerEditTrack");
+        this.viewerEditBar = document.getElementById("viewerEditBar");
+        this.viewerEditHint = document.getElementById("viewerEditHint");
+        this.editAddPointBtn = document.getElementById("editAddPointBtn");
+        this.editDeletePointBtn = document.getElementById("editDeletePointBtn");
+        this.editResetBtn = document.getElementById("editResetBtn");
+        this.editDoneBtn = document.getElementById("editDoneBtn");
 
         this.uploadView = document.getElementById("uploadView");
         this.backToLibrary = document.getElementById("backToLibrary");
@@ -193,6 +209,11 @@ class RallyClipApp {
         this.viewerCsvBtn.addEventListener("click", () => {
             if (this.viewingItemId) this.triggerDownload(`/api/library/${this.viewingItemId}/csv`);
         });
+        this.viewerEditBtn.addEventListener("click", () => this.enterEditMode());
+        this.editAddPointBtn.addEventListener("click", () => this.addPointAtCurrentTime());
+        this.editDeletePointBtn.addEventListener("click", () => this.deleteSelectedPoint());
+        this.editResetBtn.addEventListener("click", () => this.resetSegmentEdits());
+        this.editDoneBtn.addEventListener("click", () => this.exitEditMode());
         [this.primaryMatchVideo, this.secondaryMatchVideo].forEach((video) => this.bindViewerVideoEvents(video));
         this.viewerVideoWrap.addEventListener("pointermove", () => this.showViewerControls());
         this.viewerVideoWrap.addEventListener("pointerenter", () => this.showViewerControls());
@@ -495,6 +516,8 @@ class RallyClipApp {
         this.uploadView.hidden = viewName !== "upload";
         this.progressCard.hidden = viewName !== "processing";
         if (viewName !== "viewer" && this.matchVideo) {
+            this.exitEditMode({ silent: true });
+            this.segmentsEdited = false;
             this.clearPreviewPoll();
             this.resetMsePreview();
             this.resetViewerVideos();
@@ -559,6 +582,7 @@ class RallyClipApp {
             clearTimeout(this.viewerControlsHideTimeout);
             this.viewerControlsHideTimeout = null;
         }
+        if (this.editMode) return;
         if (!this.viewerVideoWrap) return;
         this.viewerVideoWrap.classList.remove("is-controls-visible");
         this.viewerVideoWrap.classList.add("is-controls-idle");
@@ -773,6 +797,9 @@ class RallyClipApp {
         this.viewerTitle.textContent = item.name || "Match";
         this.viewerMeta.textContent = item.metaText || this.cardMeta(item);
         this.viewerCsvBtn.hidden = !item.has_csv;
+        this.exitEditMode({ silent: true });
+        this.viewerEditBtn.hidden = !item.has_csv;
+        this.segmentsEdited = Boolean(item.has_edits);
         this.directPlayback = false;
         this.resetViewerVideos();
         this.updateViewerControls();
@@ -1480,6 +1507,8 @@ class RallyClipApp {
     }
 
     setPlaybackSegmentForSourceTime(sourceTime) {
+        // While editing, never auto-skip between points; play straight through.
+        if (this.editMode) return this.setManualPlaybackSegmentForSourceTime(sourceTime);
         this.activePlaybackSegment = this.playbackSegmentForSourceTime(sourceTime);
         return this.activePlaybackSegment;
     }
@@ -1925,6 +1954,7 @@ class RallyClipApp {
             const payload = await resp.json();
             if (this.viewingItemId !== itemId) return;
             this.pointIntervals = this.normalizePointIntervals(payload.segments);
+            this.segmentsEdited = Boolean(payload.edited);
             this.lastViewerTime = null;
             this.renderViewerPointRanges();
         } catch (err) {
@@ -1962,6 +1992,313 @@ class RallyClipApp {
             marker.style.width = `${Math.max(0.12, ((end - start) / duration) * 100)}%`;
             this.viewerPointTrack.appendChild(marker);
         });
+        if (this.editMode) this.renderEditTrack();
+    }
+
+    // ----- Segment edit mode ------------------------------------------------ //
+    // Edits live in segments_edited.csv on the server; segments.csv (the model
+    // output) is never modified, so "Reset to original" is always possible.
+
+    async enterEditMode() {
+        if (this.editMode || !this.viewingItemId) return;
+        const itemId = this.viewingItemId;
+        try {
+            const resp = await fetch(`/api/library/${itemId}/segments`);
+            if (resp.ok) {
+                const payload = await resp.json();
+                if (this.viewingItemId !== itemId) return;
+                this.pointIntervals = this.normalizePointIntervals(payload.segments);
+                this.segmentsEdited = Boolean(payload.edited);
+            }
+        } catch (err) {
+            console.warn("Could not refresh point times before editing", err);
+        }
+        if (this.viewingItemId !== itemId) return;
+        this.editMode = true;
+        this.editSelectedIndex = this.pointIntervals.length ? 0 : -1;
+        if (this.viewerHasVideo()) this.matchVideo.pause();
+        this.setManualPlaybackSegmentForSourceTime(this.getViewerSourceTime());
+        this.updateViewerControls();
+        this.showViewerControls();
+        this.renderViewerPointRanges();
+        this.renderEditTrack();
+        this.setEditHintForSegment(this.editSelectedIndex);
+    }
+
+    exitEditMode(options = {}) {
+        const wasEditing = this.editMode;
+        this.editMode = false;
+        this.editDrag = null;
+        this.editSelectedIndex = -1;
+        this.editScrubPending = null;
+        if (this.viewerEditTrack) {
+            this.viewerEditTrack.innerHTML = "";
+            this.viewerEditTrack.hidden = true;
+        }
+        if (this.viewerEditBar) this.viewerEditBar.hidden = true;
+        if (this.viewerVideoWrap) this.viewerVideoWrap.classList.remove("is-editing");
+        if (this.viewerEditBtn) {
+            this.viewerEditBtn.disabled = false;
+            this.viewerEditBtn.textContent = "Edit points";
+        }
+        if (!wasEditing) return;
+        if (this.viewingItemId) this.setPlaybackSegmentForSourceTime(this.getViewerSourceTime());
+        if (!options.silent && this.segmentsEdited) this.showToast("Point edits saved.", "success");
+    }
+
+    updateEditUi() {
+        if (!this.viewerEditBar) return;
+        this.viewerEditBar.hidden = !this.editMode;
+        this.viewerEditTrack.hidden = !this.editMode;
+        if (this.viewerVideoWrap) this.viewerVideoWrap.classList.toggle("is-editing", this.editMode);
+        if (this.viewerEditBtn) {
+            this.viewerEditBtn.disabled = this.editMode;
+            this.viewerEditBtn.textContent = this.editMode ? "Editing points" : "Edit points";
+        }
+        this.editDeletePointBtn.disabled = !this.editMode || this.editSelectedIndex < 0;
+        this.editResetBtn.disabled = !this.editMode || !this.segmentsEdited;
+    }
+
+    editTrackDuration() {
+        return Math.max(0, Number(this.sourceDuration) || 0);
+    }
+
+    editTimeFromClientX(clientX) {
+        const rect = this.viewerSeekWrap.getBoundingClientRect();
+        const duration = this.editTrackDuration();
+        if (!rect.width || duration <= 0) return 0;
+        const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+        return ratio * duration;
+    }
+
+    renderEditTrack() {
+        if (!this.viewerEditTrack || this.editDrag) return;
+        this.viewerEditTrack.innerHTML = "";
+        this.updateEditUi();
+        if (!this.editMode) return;
+        const duration = this.editTrackDuration();
+        if (duration <= 0) return;
+        if (this.editSelectedIndex >= this.pointIntervals.length) this.editSelectedIndex = -1;
+        this.pointIntervals.forEach((seg, index) => {
+            const el = document.createElement("div");
+            el.className = "viewer-edit-segment";
+            el.dataset.index = String(index);
+            if (index === this.editSelectedIndex) {
+                el.classList.add("is-selected");
+                ["start", "end"].forEach((edge) => {
+                    const handle = document.createElement("div");
+                    handle.className = "viewer-edit-handle";
+                    handle.dataset.edge = edge;
+                    handle.addEventListener("pointerdown", (e) => this.onEditHandlePointerDown(e, index, edge));
+                    handle.addEventListener("pointermove", (e) => this.onEditHandlePointerMove(e));
+                    handle.addEventListener("pointerup", (e) => this.onEditHandlePointerUp(e));
+                    handle.addEventListener("pointercancel", (e) => this.onEditHandlePointerUp(e));
+                    el.appendChild(handle);
+                });
+            }
+            el.addEventListener("pointerdown", (e) => this.onEditSegmentPointerDown(e, index));
+            this.positionEditSegment(index, el, duration);
+            this.viewerEditTrack.appendChild(el);
+        });
+    }
+
+    positionEditSegment(index, el = null, duration = this.editTrackDuration()) {
+        const seg = this.pointIntervals[index];
+        const element = el || this.viewerEditTrack?.querySelector(`[data-index="${index}"]`);
+        if (!seg || !element || duration <= 0) return;
+        const startPct = Math.max(0, Math.min(100, (seg.start / duration) * 100));
+        const endPct = Math.max(startPct, Math.min(100, (seg.end / duration) * 100));
+        element.style.left = `${startPct}%`;
+        element.style.width = `${Math.max(0.4, endPct - startPct)}%`;
+    }
+
+    setEditHintForSegment(index) {
+        if (!this.viewerEditHint) return;
+        const seg = this.pointIntervals[index];
+        if (!seg) {
+            this.viewerEditHint.textContent = "Tap a point, then drag its ends to trim.";
+            return;
+        }
+        this.viewerEditHint.textContent =
+            `Point ${index + 1} of ${this.pointIntervals.length}: ` +
+            `${this.formatClock(seg.start)} - ${this.formatClock(seg.end)}`;
+    }
+
+    onEditSegmentPointerDown(event, index) {
+        event.stopPropagation();
+        if (event.target.classList.contains("viewer-edit-handle")) return;
+        const seg = this.pointIntervals[index];
+        if (!seg) return;
+        if (this.editSelectedIndex !== index) {
+            this.editSelectedIndex = index;
+            this.renderEditTrack();
+        }
+        if (this.viewerHasVideo()) this.matchVideo.pause();
+        this.seekViewerToSourceTime(seg.start, false);
+        this.setEditHintForSegment(index);
+        this.updateEditUi();
+    }
+
+    onEditHandlePointerDown(event, index, edge) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        this.editDrag = { index, edge, pointerId: event.pointerId, moved: false };
+        this.editSelectedIndex = index;
+        if (this.viewerHasVideo()) this.matchVideo.pause();
+        this.updateEditUi();
+    }
+
+    onEditHandlePointerMove(event) {
+        const drag = this.editDrag;
+        if (!drag || event.pointerId !== drag.pointerId) return;
+        const seg = this.pointIntervals[drag.index];
+        if (!seg) return;
+        event.preventDefault();
+        const t = this.editTimeFromClientX(event.clientX);
+        let clamped;
+        if (drag.edge === "start") {
+            const min = this.pointIntervals[drag.index - 1]?.end ?? 0;
+            const max = seg.end - this.minPointSeconds;
+            clamped = Math.min(max, Math.max(min, t));
+            seg.start = Number(clamped.toFixed(3));
+        } else {
+            const min = seg.start + this.minPointSeconds;
+            const max = this.pointIntervals[drag.index + 1]?.start ?? this.editTrackDuration();
+            clamped = Math.min(max, Math.max(min, t));
+            seg.end = Number(clamped.toFixed(3));
+        }
+        drag.moved = true;
+        this.positionEditSegment(drag.index);
+        this.setEditHintForSegment(drag.index);
+        this.scrubEditPreview(clamped);
+    }
+
+    onEditHandlePointerUp(event) {
+        const drag = this.editDrag;
+        if (!drag || event.pointerId !== drag.pointerId) return;
+        this.editDrag = null;
+        this.renderViewerPointRanges();
+        this.renderEditTrack();
+        if (drag.moved) this.queueSegmentsSave();
+    }
+
+    scrubEditPreview(sourceTime) {
+        // Live-scrub the frame under the dragged handle (Photos-style). Only in
+        // direct playback: the fallback window pipeline would kick off a WebM
+        // transcode per pointermove.
+        if (!this.directPlayback || !this.matchVideo.src) return;
+        const alreadyQueued = this.editScrubPending !== null;
+        this.editScrubPending = sourceTime;
+        if (alreadyQueued) return;
+        requestAnimationFrame(() => {
+            const t = this.editScrubPending;
+            this.editScrubPending = null;
+            if (!this.editMode || !Number.isFinite(t)) return;
+            const target = this.clampViewerSourceTime(t);
+            this.matchVideo.currentTime = target;
+            this.lastViewerTime = target;
+            this.updateViewerTimeline(target);
+        });
+    }
+
+    addPointAtCurrentTime() {
+        if (!this.editMode) return;
+        const duration = this.editTrackDuration();
+        if (duration <= 0) return;
+        const t = this.clampViewerSourceTime(this.getViewerSourceTime());
+        const existing = this.pointIndexAtSourceTime(t);
+        if (existing >= 0) {
+            this.editSelectedIndex = existing;
+            this.renderEditTrack();
+            this.setEditHintForSegment(existing);
+            this.showToast("There is already a point here.", "error");
+            return;
+        }
+        const prevEnd = this.pointIntervals.reduce((acc, seg) => (seg.end <= t ? Math.max(acc, seg.end) : acc), 0);
+        const nextIndex = this.nextPointIndexAfterSourceTime(t);
+        const nextStart = nextIndex >= 0 ? this.pointIntervals[nextIndex].start : duration;
+        let start = Math.max(t, prevEnd);
+        const end = Math.min(start + this.addPointSeconds, nextStart, duration);
+        start = Math.max(prevEnd, Math.min(start, end - this.addPointSeconds));
+        start = Math.max(prevEnd, Math.min(start, end - this.minPointSeconds));
+        if (!(end - start >= this.minPointSeconds)) {
+            this.showToast("Not enough room for a new point here.", "error");
+            return;
+        }
+        const seg = { start: Number(start.toFixed(3)), end: Number(end.toFixed(3)) };
+        this.pointIntervals.push(seg);
+        this.pointIntervals.sort((a, b) => a.start - b.start || a.end - b.end);
+        this.editSelectedIndex = this.pointIntervals.indexOf(seg);
+        this.renderViewerPointRanges();
+        this.renderEditTrack();
+        this.setEditHintForSegment(this.editSelectedIndex);
+        this.queueSegmentsSave();
+    }
+
+    deleteSelectedPoint() {
+        if (!this.editMode) return;
+        let index = this.editSelectedIndex;
+        if (index < 0) index = this.pointIndexAtSourceTime(this.getViewerSourceTime());
+        if (index < 0 || !this.pointIntervals[index]) {
+            this.showToast("Select a point to delete.", "error");
+            return;
+        }
+        this.pointIntervals.splice(index, 1);
+        this.editSelectedIndex = -1;
+        this.renderViewerPointRanges();
+        this.renderEditTrack();
+        this.setEditHintForSegment(-1);
+        this.queueSegmentsSave();
+    }
+
+    async resetSegmentEdits() {
+        if (!this.viewingItemId || !this.segmentsEdited) return;
+        if (!window.confirm("Discard your edits and go back to the original point times?")) return;
+        const itemId = this.viewingItemId;
+        try {
+            const resp = await fetch(`/api/library/${itemId}/segments/edits`, { method: "DELETE" });
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const payload = await resp.json();
+            if (this.viewingItemId !== itemId) return;
+            this.pointIntervals = this.normalizePointIntervals(payload.segments);
+            this.segmentsEdited = Boolean(payload.edited);
+            this.editSelectedIndex = -1;
+            this.renderViewerPointRanges();
+            this.renderEditTrack();
+            this.setEditHintForSegment(-1);
+            this.showToast("Points reset to the original.", "success");
+        } catch (err) {
+            console.error(err);
+            this.showToast("Could not reset points.", "error");
+        }
+    }
+
+    queueSegmentsSave() {
+        if (!this.viewingItemId) return;
+        const itemId = this.viewingItemId;
+        const segments = this.pointIntervals.map((seg) => ({ start: seg.start, end: seg.end }));
+        // Serialize PUTs so rapid edits can't land on the server out of order.
+        this.editSaveChain = this.editSaveChain
+            .then(() => fetch(`/api/library/${itemId}/segments`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ segments }),
+            }))
+            .then(async (resp) => {
+                if (!resp.ok) {
+                    const payload = await resp.json().catch(() => ({}));
+                    throw new Error(payload.error || `HTTP ${resp.status}`);
+                }
+                const payload = await resp.json();
+                if (this.viewingItemId !== itemId) return;
+                this.segmentsEdited = Boolean(payload.edited);
+                this.updateEditUi();
+            })
+            .catch((err) => {
+                console.error(err);
+                if (this.viewingItemId === itemId) this.showToast("Could not save point edits.", "error");
+            });
     }
 
     formatClock(seconds) {
@@ -2111,6 +2448,7 @@ class RallyClipApp {
     }
 
     advanceAfterActivePlaybackSegment() {
+        if (this.editMode) return;
         if (!this.activePlaybackSegment || this.previewLoadInProgress) return;
         const nextPointIndex = this.activePlaybackSegment.nextPointIndex;
         if (Number.isInteger(nextPointIndex) && this.pointIntervals[nextPointIndex]) {

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -57,6 +57,8 @@ class RallyClipApp {
         this.editDrag = null;
         this.editScrubPending = null;
         this.editSaveChain = Promise.resolve();
+        this.editSaveGen = 0;
+        this.editSessionDirty = false;
         this.segmentsEdited = false;
         this.minPointSeconds = 0.5;
         this.addPointSeconds = 8;
@@ -518,6 +520,11 @@ class RallyClipApp {
         if (viewName !== "viewer" && this.matchVideo) {
             this.exitEditMode({ silent: true });
             this.segmentsEdited = false;
+            // Orphan the old item's autosave queue so the next item's saves
+            // don't wait behind it (queued ones no-op via the generation bump).
+            this.editSaveGen += 1;
+            this.editSaveChain = Promise.resolve();
+            this.editSessionDirty = false;
             this.clearPreviewPoll();
             this.resetMsePreview();
             this.resetViewerVideos();
@@ -800,6 +807,9 @@ class RallyClipApp {
         this.exitEditMode({ silent: true });
         this.viewerEditBtn.hidden = !item.has_csv;
         this.segmentsEdited = Boolean(item.has_edits);
+        this.editSaveGen += 1;
+        this.editSaveChain = Promise.resolve();
+        this.editSessionDirty = false;
         this.directPlayback = false;
         this.resetViewerVideos();
         this.updateViewerControls();
@@ -2043,7 +2053,8 @@ class RallyClipApp {
         }
         if (!wasEditing) return;
         if (this.viewingItemId) this.setPlaybackSegmentForSourceTime(this.getViewerSourceTime());
-        if (!options.silent && this.segmentsEdited) this.showToast("Point edits saved.", "success");
+        if (!options.silent && this.editSessionDirty) this.showToast("Point edits saved.", "success");
+        this.editSessionDirty = false;
     }
 
     updateEditUi() {
@@ -2056,7 +2067,9 @@ class RallyClipApp {
             this.viewerEditBtn.textContent = this.editMode ? "Editing points" : "Edit points";
         }
         this.editDeletePointBtn.disabled = !this.editMode || this.editSelectedIndex < 0;
-        this.editResetBtn.disabled = !this.editMode || !this.segmentsEdited;
+        // Local unsaved changes count too: a failed autosave must not lock the
+        // user out of Reset.
+        this.editResetBtn.disabled = !this.editMode || (!this.segmentsEdited && !this.editSessionDirty);
     }
 
     editTrackDuration() {
@@ -2253,16 +2266,23 @@ class RallyClipApp {
     }
 
     async resetSegmentEdits() {
-        if (!this.viewingItemId || !this.segmentsEdited) return;
+        if (!this.viewingItemId || (!this.segmentsEdited && !this.editSessionDirty)) return;
         if (!window.confirm("Discard your edits and go back to the original point times?")) return;
         const itemId = this.viewingItemId;
+        // Invalidate queued autosaves so a stale PUT can't recreate the edited
+        // CSV after the DELETE, then wait out any PUT already on the wire.
+        this.editSaveGen += 1;
+        const inFlight = this.editSaveChain;
+        this.editSaveChain = Promise.resolve();
         try {
+            await inFlight.catch(() => {});
             const resp = await fetch(`/api/library/${itemId}/segments/edits`, { method: "DELETE" });
             if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             const payload = await resp.json();
             if (this.viewingItemId !== itemId) return;
             this.pointIntervals = this.normalizePointIntervals(payload.segments);
             this.segmentsEdited = Boolean(payload.edited);
+            this.editSessionDirty = false;
             this.editSelectedIndex = -1;
             this.renderViewerPointRanges();
             this.renderEditTrack();
@@ -2277,27 +2297,37 @@ class RallyClipApp {
     queueSegmentsSave() {
         if (!this.viewingItemId) return;
         const itemId = this.viewingItemId;
+        const gen = this.editSaveGen;
+        this.editSessionDirty = true;
+        this.updateEditUi();
         const segments = this.pointIntervals.map((seg) => ({ start: seg.start, end: seg.end }));
-        // Serialize PUTs so rapid edits can't land on the server out of order.
+        // Serialize PUTs so rapid edits can't land on the server out of order;
+        // a generation bump (reset / item switch) turns queued saves into no-ops.
         this.editSaveChain = this.editSaveChain
-            .then(() => fetch(`/api/library/${itemId}/segments`, {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ segments }),
-            }))
+            .then(() => {
+                if (this.editSaveGen !== gen || this.viewingItemId !== itemId) return null;
+                return fetch(`/api/library/${itemId}/segments`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ segments }),
+                });
+            })
             .then(async (resp) => {
+                if (!resp) return;
                 if (!resp.ok) {
                     const payload = await resp.json().catch(() => ({}));
                     throw new Error(payload.error || `HTTP ${resp.status}`);
                 }
                 const payload = await resp.json();
-                if (this.viewingItemId !== itemId) return;
+                if (this.editSaveGen !== gen || this.viewingItemId !== itemId) return;
                 this.segmentsEdited = Boolean(payload.edited);
                 this.updateEditUi();
             })
             .catch((err) => {
                 console.error(err);
-                if (this.viewingItemId === itemId) this.showToast("Could not save point edits.", "error");
+                if (this.editSaveGen === gen && this.viewingItemId === itemId) {
+                    this.showToast("Could not save point edits.", "error");
+                }
             });
     }
 

--- a/src/gui/frontend/styles.css
+++ b/src/gui/frontend/styles.css
@@ -698,6 +698,90 @@ select {
     box-shadow: 0 0 0 4px rgba(204, 255, 0, 0.16), 0 2px 12px rgba(0, 0, 0, 0.72);
 }
 
+/* ----- Segment edit mode ----- */
+.btn-small {
+    padding: 0.42rem 0.85rem;
+    font-size: 0.92rem;
+}
+
+.viewer-edit-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 0.35rem;
+}
+
+.viewer-edit-hint {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.88);
+    min-width: 0;
+}
+
+.viewer-edit-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.viewer-edit-track {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 3;
+}
+
+.viewer-edit-segment {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 0.95rem;
+    border-radius: 0.35rem;
+    background: rgba(204, 255, 0, 0.42);
+    border: 1px solid rgba(204, 255, 0, 0.75);
+    pointer-events: auto;
+    cursor: pointer;
+    touch-action: none;
+}
+
+.viewer-edit-segment.is-selected {
+    background: rgba(204, 255, 0, 0.62);
+    border-color: var(--tennis);
+    height: 1.25rem;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+
+.viewer-edit-handle {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 0.85rem;
+    height: 1.7rem;
+    border-radius: 0.3rem;
+    background: var(--tennis);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.7);
+    pointer-events: auto;
+    cursor: ew-resize;
+    touch-action: none;
+}
+
+.viewer-edit-handle[data-edge="start"] {
+    left: 0;
+}
+
+.viewer-edit-handle[data-edge="end"] {
+    left: 100%;
+}
+
+.viewer-video-wrap.is-editing .viewer-overlay {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
 .empty-title {
     margin: 0 0 0.35rem;
     font-size: 1.7rem;

--- a/src/rallyclip_core/intervals.py
+++ b/src/rallyclip_core/intervals.py
@@ -30,6 +30,20 @@ def read_point_intervals(csv_path: Optional[Path]) -> List[Interval]:
     return sorted(intervals, key=lambda item: (item[0], item[1]))
 
 
+def write_point_intervals(csv_path: Path, intervals: Iterable[Interval]) -> None:
+    """Write point intervals in the segments.csv contract (3-decimal seconds).
+
+    Writes via a temp file + replace so readers never observe a partial CSV.
+    """
+    tmp_path = csv_path.with_name(csv_path.name + ".tmp")
+    with tmp_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerow(["start_time", "end_time"])
+        for start, end in intervals:
+            writer.writerow([f"{start:.3f}", f"{end:.3f}"])
+    tmp_path.replace(csv_path)
+
+
 def point_duration(intervals: Iterable[Interval]) -> float:
     return sum(end - start for start, end in intervals)
 

--- a/src/rallyclip_core/library.py
+++ b/src/rallyclip_core/library.py
@@ -120,8 +120,11 @@ class SavedMatchStore:
             except Exception:
                 continue
             meta["id"] = child.name  # trust the folder name, not the file contents
-            meta["has_csv"] = (child / SEGMENTS_FILENAME).exists()
-            meta["has_edits"] = (child / EDITED_SEGMENTS_FILENAME).exists()
+            has_edits = (child / EDITED_SEGMENTS_FILENAME).exists()
+            # has_csv means "point times are available" — the edited copy
+            # counts, matching what resolve_segments serves downstream.
+            meta["has_csv"] = (child / SEGMENTS_FILENAME).exists() or has_edits
+            meta["has_edits"] = has_edits
             meta["has_thumbnail"] = (child / THUMBNAIL_FILENAME).exists()
             meta["has_export"] = (child / EXPORT_FILENAME).exists()
             items.append(meta)

--- a/src/rallyclip_core/library.py
+++ b/src/rallyclip_core/library.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional
 SOURCE_FILENAME = "source.mp4"
 LEGACY_SOURCE_FILENAME = "video.mp4"
 SEGMENTS_FILENAME = "segments.csv"
+EDITED_SEGMENTS_FILENAME = "segments_edited.csv"
 META_FILENAME = "meta.json"
 THUMBNAIL_FILENAME = "thumb.jpg"
 EXPORT_FILENAME = "export.mp4"
@@ -67,6 +68,30 @@ class SavedMatchStore:
                 return path
         return None
 
+    def resolve_segments(self, item_id: str) -> Optional[Path]:
+        """Resolve the effective point-times CSV for a library item.
+
+        ``segments_edited.csv`` (user edits) wins over the model-produced
+        ``segments.csv``; the original is never modified so edits can always
+        be reset.
+        """
+        try:
+            item_dir = self.item_dir(item_id)
+        except ValueError:
+            return None
+        for filename in (EDITED_SEGMENTS_FILENAME, SEGMENTS_FILENAME):
+            path = item_dir / filename
+            if path.exists():
+                return path
+        return None
+
+    def has_edited_segments(self, item_id: str) -> bool:
+        try:
+            item_dir = self.item_dir(item_id)
+        except ValueError:
+            return False
+        return (item_dir / EDITED_SEGMENTS_FILENAME).exists()
+
     def read_meta(self, item_dir: Path) -> Dict[str, Any]:
         meta_path = item_dir / META_FILENAME
         if not meta_path.exists():
@@ -96,6 +121,7 @@ class SavedMatchStore:
                 continue
             meta["id"] = child.name  # trust the folder name, not the file contents
             meta["has_csv"] = (child / SEGMENTS_FILENAME).exists()
+            meta["has_edits"] = (child / EDITED_SEGMENTS_FILENAME).exists()
             meta["has_thumbnail"] = (child / THUMBNAIL_FILENAME).exists()
             meta["has_export"] = (child / EXPORT_FILENAME).exists()
             items.append(meta)

--- a/tests/test_api_route_contracts.py
+++ b/tests/test_api_route_contracts.py
@@ -109,6 +109,7 @@ def test_library_response_contract(client, monkeypatch, tmp_path):
             "point_duration_s": 21.6,
             "n_segments": 2,
             "has_csv": True,
+            "has_edits": False,
             "has_thumbnail": False,
             "has_export": False,
         }

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -677,6 +677,89 @@ def test_ui_viewer_uses_source_timeline_scheduler(page: Page, ui_backend: Backen
     assert timeline_config_preserves_time == {"value": 42.5, "current": "0:42", "duration": "2:00"}
 
 
+def test_ui_segment_edit_mode_trims_adds_deletes_and_resets(page: Page, ui_backend: BackendClient):
+    """Edit mode: drag-trim a point, add and delete points, then reset. Edits
+    land in segments_edited.csv; segments.csv is never touched."""
+    from gui import app as gui_app
+
+    item_id = _fabricate_viewer_item()
+    item_dir = Path(gui_app.LIBRARY_DIR) / item_id
+    original_csv = (item_dir / "segments.csv").read_text(encoding="utf-8")
+    _open_to_library(page, ui_backend.base_url)
+
+    page.locator(f'.lib-card[data-id="{item_id}"]').click()
+    expect(page.locator("#viewerView")).to_be_visible()
+    expect(page.locator("#viewerTimeline")).to_be_visible(timeout=30_000)
+    page.wait_for_function(
+        "() => Boolean(window.rallyClipApp?.viewerHasVideo?.())",
+        timeout=30_000,
+    )
+
+    page.locator("#viewerEditBtn").click()
+    expect(page.locator("#viewerEditBar")).to_be_visible()
+    expect(page.locator(".viewer-edit-segment")).to_have_count(2)
+    # First point is auto-selected with trim handles.
+    selected = page.locator(".viewer-edit-segment.is-selected")
+    expect(selected).to_have_count(1)
+    expect(selected.locator(".viewer-edit-handle")).to_have_count(2)
+
+    # Drag the end handle right: point 1 (1.0-2.0 of a 12s clip) stretches
+    # toward 3s. The track spans the seek wrap, so 1s = 1/12 of its width.
+    wrap_box = page.locator(".viewer-seek-wrap").bounding_box()
+    handle_box = selected.locator('.viewer-edit-handle[data-edge="end"]').bounding_box()
+    start_x = handle_box["x"] + handle_box["width"] / 2
+    start_y = handle_box["y"] + handle_box["height"] / 2
+    page.mouse.move(start_x, start_y)
+    page.mouse.down()
+    page.mouse.move(start_x + wrap_box["width"] / 12, start_y, steps=8)
+    page.mouse.up()
+
+    page.wait_for_function(
+        f"""() => fetch('/api/library/{item_id}/segments')
+            .then((r) => r.json())
+            .then((p) => p.edited && p.segments[0].end > 2.4 && p.segments[0].end < 3.6)"""
+    )
+    assert (item_dir / "segments_edited.csv").exists()
+    assert (item_dir / "segments.csv").read_text(encoding="utf-8") == original_csv
+
+    # Add a point at ~8s (a gap), then delete it again. In preview-window
+    # fallback mode the seek lands asynchronously, so wait for it to settle
+    # before adding (add uses the current playback time).
+    page.evaluate("() => window.rallyClipApp.seekViewerToSourceTime(8, false)")
+    page.wait_for_function(
+        "() => Math.abs(window.rallyClipApp.getViewerSourceTime() - 8) < 0.5",
+        timeout=30_000,
+    )
+    page.locator("#editAddPointBtn").click()
+    expect(page.locator(".viewer-edit-segment")).to_have_count(3)
+    page.wait_for_function(
+        f"""() => fetch('/api/library/{item_id}/segments')
+            .then((r) => r.json())
+            .then((p) => p.segments.length === 3)"""
+    )
+    page.locator("#editDeletePointBtn").click()
+    expect(page.locator(".viewer-edit-segment")).to_have_count(2)
+
+    # Reset discards the edited copy and restores the original times.
+    page.on("dialog", lambda dialog: dialog.accept())
+    expect(page.locator("#editResetBtn")).to_be_enabled()
+    page.locator("#editResetBtn").click()
+    page.wait_for_function(
+        f"""() => fetch('/api/library/{item_id}/segments')
+            .then((r) => r.json())
+            .then((p) => !p.edited && p.segments.length === 2 && p.segments[0].end === 2)"""
+    )
+    assert not (item_dir / "segments_edited.csv").exists()
+    edit_state = page.evaluate(
+        "() => ({ points: window.rallyClipApp.pointIntervals, edited: window.rallyClipApp.segmentsEdited })"
+    )
+    assert edit_state["points"] == [{"start": 1, "end": 2}, {"start": 4, "end": 5}]
+    assert edit_state["edited"] is False
+
+    page.locator("#editDoneBtn").click()
+    expect(page.locator("#viewerEditBar")).to_be_hidden()
+
+
 def test_ui_new_match_runs_to_library(page: Page, ui_backend: BackendClient, ui_clip: Path):
     """Full UI journey: library -> New match -> pick file -> Start -> progress ->
     back to the library on completion. The synthetic clip finds no points, so no

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -753,6 +753,8 @@ def test_frozen_data_root_migrates_legacy_home_dir(tmp_path, monkeypatch):
     (tmp_path / "RallyClip").mkdir()
     assert gui_app._frozen_data_root() == root
     assert (tmp_path / "RallyClip").is_dir()
+
+
 def test_library_source_streams_with_range_support(tmp_path, monkeypatch):
     from gui import app as gui_app
 
@@ -775,3 +777,117 @@ def test_library_source_streams_with_range_support(tmp_path, monkeypatch):
     assert partial.headers.get("Content-Range") == "bytes 4-7/16"
 
     assert client.get("/api/library/no-such-item/source").status_code == 404
+
+
+def test_segment_edits_roundtrip_without_touching_original(tmp_path, monkeypatch):
+    from gui import app as gui_app
+
+    library = tmp_path / "library"
+    item_dir = library / "match-1"
+    item_dir.mkdir(parents=True)
+    (item_dir / "source.mp4").write_bytes(b"full video")
+    original_csv = "start_time,end_time\n1.0,3.0\n4.0,5.0\n"
+    (item_dir / "segments.csv").write_text(original_csv, encoding="utf-8")
+    (item_dir / "meta.json").write_text('{"name": "Match 1", "duration_s": 60.0}', encoding="utf-8")
+    monkeypatch.setattr(gui_app, "LIBRARY_DIR", library)
+    client = gui_app.app.test_client()
+
+    before = client.get("/api/library/match-1/segments").get_json()
+    assert before["edited"] is False
+    assert before["segments"] == [{"start": 1.0, "end": 3.0}, {"start": 4.0, "end": 5.0}]
+
+    saved = client.put(
+        "/api/library/match-1/segments",
+        json={"segments": [{"start": 0.5, "end": 3.5}, {"start": 10.0, "end": 12.0}]},
+    )
+    assert saved.status_code == 200
+    payload = saved.get_json()
+    assert payload["edited"] is True
+    assert payload["segments"] == [{"start": 0.5, "end": 3.5}, {"start": 10.0, "end": 12.0}]
+
+    # Original is untouched; the edited copy holds the new times.
+    assert (item_dir / "segments.csv").read_text(encoding="utf-8") == original_csv
+    edited = (item_dir / "segments_edited.csv").read_text(encoding="utf-8")
+    assert edited == "start_time,end_time\n0.500,3.500\n10.000,12.000\n"
+
+    # Every consumer now sees the edited times.
+    assert client.get("/api/library/match-1/segments").get_json()["segments"] == payload["segments"]
+    manifest = client.get("/api/library/match-1/playback").get_json()
+    assert manifest["point_intervals"] == [{"start": 0.5, "end": 3.5}, {"start": 10.0, "end": 12.0}]
+    download = client.get("/api/library/match-1/csv")
+    assert download.data.decode("utf-8") == edited
+
+    # Reset restores the original and deletes the copy.
+    reset = client.delete("/api/library/match-1/segments/edits")
+    assert reset.status_code == 200
+    payload = reset.get_json()
+    assert payload["edited"] is False
+    assert payload["segments"] == [{"start": 1.0, "end": 3.0}, {"start": 4.0, "end": 5.0}]
+    assert not (item_dir / "segments_edited.csv").exists()
+    assert (item_dir / "segments.csv").read_text(encoding="utf-8") == original_csv
+
+
+def test_segment_edits_validation_and_missing_item(tmp_path, monkeypatch):
+    from gui import app as gui_app
+
+    library = tmp_path / "library"
+    item_dir = library / "match-1"
+    item_dir.mkdir(parents=True)
+    (item_dir / "source.mp4").write_bytes(b"full video")
+    (item_dir / "segments.csv").write_text("start_time,end_time\n1.0,3.0\n", encoding="utf-8")
+    monkeypatch.setattr(gui_app, "LIBRARY_DIR", library)
+    client = gui_app.app.test_client()
+
+    bad_bodies = [
+        None,
+        {"segments": [{"start": 3.0, "end": 1.0}]},
+        {"segments": [{"start": -1.0, "end": 2.0}]},
+        {"segments": [{"start": "x", "end": 2.0}]},
+        {"segments": [{"start": 1.0, "end": 4.0}, {"start": 3.0, "end": 6.0}]},
+    ]
+    for body in bad_bodies:
+        resp = client.put("/api/library/match-1/segments", json=body)
+        assert resp.status_code == 400, body
+    assert not (item_dir / "segments_edited.csv").exists()
+
+    assert client.put(
+        "/api/library/no-such/segments", json={"segments": [{"start": 1.0, "end": 2.0}]}
+    ).status_code == 404
+    assert client.delete("/api/library/no-such/segments/edits").status_code == 404
+
+
+def test_segment_edits_invalidate_lazy_export(tmp_path, monkeypatch):
+    from gui import app as gui_app
+
+    library = tmp_path / "library"
+    item_dir = library / "match-1"
+    item_dir.mkdir(parents=True)
+    source = item_dir / "source.mp4"
+    source.write_bytes(b"full video")
+    (item_dir / "segments.csv").write_text("start_time,end_time\n1.0,3.0\n", encoding="utf-8")
+    (item_dir / "meta.json").write_text('{"name": "Match 1"}', encoding="utf-8")
+    monkeypatch.setattr(gui_app, "LIBRARY_DIR", library)
+    calls = []
+
+    def fake_segment_video(input_video, intervals_sec, output_video):
+        calls.append(intervals_sec)
+        Path(output_video).write_bytes(b"cut video")
+
+    monkeypatch.setattr(gui_app, "segment_video", fake_segment_video)
+    client = gui_app.app.test_client()
+
+    assert client.get("/api/library/match-1/video").status_code == 200
+    assert calls == [[(1.0, 3.0)]]
+
+    assert client.put(
+        "/api/library/match-1/segments", json={"segments": [{"start": 2.0, "end": 6.0}]}
+    ).status_code == 200
+    assert not (item_dir / "export.mp4").exists()
+
+    assert client.get("/api/library/match-1/video").status_code == 200
+    assert calls == [[(1.0, 3.0)], [(2.0, 6.0)]]
+
+    assert client.delete("/api/library/match-1/segments/edits").status_code == 200
+    assert not (item_dir / "export.mp4").exists()
+    assert client.get("/api/library/match-1/video").status_code == 200
+    assert calls == [[(1.0, 3.0)], [(2.0, 6.0)], [(1.0, 3.0)]]

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -816,6 +816,9 @@ def test_segment_edits_roundtrip_without_touching_original(tmp_path, monkeypatch
     assert manifest["point_intervals"] == [{"start": 0.5, "end": 3.5}, {"start": 10.0, "end": 12.0}]
     download = client.get("/api/library/match-1/csv")
     assert download.data.decode("utf-8") == edited
+    # send_file keeps the CSV open until the response is closed; Windows would
+    # refuse the reset's unlink below with the handle still held.
+    download.close()
 
     # Reset restores the original and deletes the copy.
     reset = client.delete("/api/library/match-1/segments/edits")
@@ -854,6 +857,13 @@ def test_segment_edits_validation_and_missing_item(tmp_path, monkeypatch):
         "/api/library/no-such/segments", json={"segments": [{"start": 1.0, "end": 2.0}]}
     ).status_code == 404
     assert client.delete("/api/library/no-such/segments/edits").status_code == 404
+
+    # Reset must not delete the edited copy when the original is missing
+    # (legacy items): it may be the only point data left.
+    (item_dir / "segments_edited.csv").write_text("start_time,end_time\n1.0,2.0\n", encoding="utf-8")
+    (item_dir / "segments.csv").unlink()
+    assert client.delete("/api/library/match-1/segments/edits").status_code == 404
+    assert (item_dir / "segments_edited.csv").exists()
 
 
 def test_segment_edits_invalidate_lazy_export(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Adds an **Edit points** mode to the saved-match viewer. Stacked on #29 (direct playback) — merge that first; this PR's own diff is the last commit.

- **Non-destructive:** edits go to `segments_edited.csv`; the model-produced `segments.csv` is never written. **Reset to original** deletes the copy.
- **Precedence:** when the edited CSV exists it wins everywhere — playback manifest, `/segments`, CSV download, and the lazy export (`export.mp4` is invalidated on edit/reset so the next download re-cuts).
- **UI (iPhone-Photos style):** tap a point on the timeline to select it, drag its end handles to trim (live frame scrub in direct playback), **Add point** at the current time, **Delete point**, **Done**. Every committed edit autosaves (PUTs serialized).
- **New routes:** `PUT /api/library/<id>/segments` (validated: finite, start<end, non-overlapping), `DELETE /api/library/<id>/segments/edits`.
- Point auto-skip is suspended while editing so scrubbing is free.

## Tests

- 3 backend unit tests: roundtrip w/ original untouched, validation + 404s, export invalidation across edit/reset — `tests/test_gui_smoke.py` 30/30.
- Playwright e2e: drag-trim via real mouse events, add, delete, reset, done — full module 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af7zsfhk4MjRJRkN9xG6gq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches segment data used for export and playback across API and UI; validation and non-destructive storage reduce corruption risk, but incorrect edits still change exported cuts until reset.
> 
> **Overview**
> Adds **Edit points** in the saved-match viewer so users can trim, add, and delete rally segments without overwriting model output.
> 
> **Backend:** User edits persist to `segments_edited.csv` via `write_point_intervals`; `SavedMatchStore.resolve_segments` prefers that file over `segments.csv`. Playback, CSV download, manifests, and lazy `export.mp4` all read the effective intervals; saving or resetting edits deletes stale `export.mp4`. New APIs: validated `PUT /api/library/<id>/segments`, `DELETE /api/library/<id>/segments/edits`; GET `/segments` includes an `edited` flag and library list exposes `has_edits`.
> 
> **Frontend:** Timeline edit mode with draggable handles, add/delete/reset/done, serialized autosave PUTs, and playback that does not auto-jump between points while editing.
> 
> **Tests:** API roundtrip/validation/export invalidation and Playwright edit-mode e2e.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c157886a23079b077b049805449a48689b1c82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->