### PR TITLE
docs: sync harness to post-merge state (PRs 28-31)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -70,3 +70,52 @@ Format per entry: date — what / why / rejected alternative. Never rewrite old 
   re-export); NeuralNetwork-format CoreML (0.25 abs divergence — actually wrong);
   CPUAndNeuralEngine-only compute units (2x — ANE alone loses to ANE+GPU "ALL");
   accelerating the LSTM (measured slower on CoreML).
+
+## 2026-07-05 — Frozen-app data lives in the OS app-data dir (PR #28)
+
+- **What:** `gui.app._frozen_data_root()` puts packaged-build user data in
+  `~/Library/Application Support/RallyClip` (macOS) / `%APPDATA%` (Windows) /
+  XDG data home (Linux), with a one-time `shutil.move` migration from the
+  v0.1.0 `~/RallyClip` location. Windows is selected via `sys.platform`.
+- **Why:** dumping a data dir in `$HOME` violates platform conventions; the
+  migration keeps v0.1.0 users' libraries. `sys.platform` (not `os.name`)
+  because pathlib picks WindowsPath/PosixPath from `os.name` at instantiation —
+  monkeypatching it breaks every `Path()` in tests on Windows.
+- **Rejected:** `Path.rename` (EXDEV across filesystems — shutil.move falls
+  back to copy+delete); zero-arg lru_cache memoization (leaks state across
+  platform-monkeypatching tests for a handful of one-time stats).
+
+## 2026-07-05 — Viewer streams the source file directly (PR #29)
+
+- **What:** `/api/library/<id>/source` serves the saved match with
+  `send_file(conditional=True)` (Range/206); the frontend models it as one
+  full-length window so the existing source-time scheduler (seeks, point
+  skips, timeline) is unchanged. WebM preview windows remain the automatic
+  fallback (probe error or 10s timeout; probes are sequence-ticketed so stale
+  callbacks are inert).
+- **Why:** the stuck-at-first-8s bug: 8s VP8/WebM windows transcode at ~2.5×
+  real time (17–22s per window, file-mtime evidence + live WebKit repro), so
+  playback stalled at every boundary. The WebM pipeline only ever existed
+  because QtWebEngine's Chromium lacked H.264 — the system webview (PR #27)
+  decodes it natively.
+- **Rejected:** speeding up the transcode (still a transcode; still burns CPU
+  and disk); MSE path (permanently dormant, `canUseMsePreview()` false);
+  deleting the window pipeline immediately (kept as codec-fallback until
+  direct playback is QA-confirmed in the wild).
+
+## 2026-07-05 — Segment edits are a shadow CSV, never the original (PR #31)
+
+- **What:** viewer edit mode writes user point edits to `segments_edited.csv`;
+  the model-produced `segments.csv` is never modified. The edited copy wins
+  everywhere (`resolve_segments`: playback manifest, /segments, CSV download,
+  lazy export — export.mp4 invalidated on edit/reset). Reset deletes the copy;
+  it refuses if the original is missing (legacy items). Frontend autosaves are
+  serialized and generation-guarded (a stale PUT can't resurrect a reset).
+- **Why:** "Reset to original" must always be possible, so the original is a
+  read-only contract; a shadow file with precedence is the smallest mechanism
+  that gives every consumer the edited times without touching the analysis
+  output. All behavior stays `/api/*` HTTP per the architecture invariant.
+- **Rejected:** editing segments.csv in place with a backup copy (reversed
+  precedence is easier to corrupt — an interrupted write loses the original);
+  edits in meta.json (two sources of truth for point times); save-on-Done only
+  (drag sessions lose work on crash; autosave matches the iPhone-Photos model).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,37 +1,59 @@
 # PROGRESS — overwrite me at every session end
 
-_Last updated: 2026-07-04 (session: torch-free runtime + system-webview shell)._
+_Last updated: 2026-07-05 (session: storage fix + direct playback + segment edit mode + CoreML spike)._
 
 ## Repo state
 
-- Branch `feat/pywebview-shell` (stacked on `feat/onnx-pose-runner`), clean, pushed.
-- Open PRs, both CI-green (3 OS × test/e2e): **#26** torch-free ONNX runtime,
-  **#27** pywebview shell. Merge #26 first, then #27; the user merges.
-- Gates: fast suite 202 passed / 1 skipped; e2e 15 passed local; golden CLI parity
-  byte-equal (incl. from the frozen bundle and a torch-free venv).
+- `main` is the release line and everything is merged: **#28** app-data storage,
+  **#29** viewer direct playback, **#30** CoreML spike docs, **#31** segment edit
+  mode. No open PRs.
+- Gates: CI green 3 OS × test/e2e on every merged PR; smoke 33 passed;
+  playwright module 7/7 (includes a real mouse-drag edit-mode e2e).
+- User is manually QA-ing a fresh DMG built from the merged code
+  (266MB .app / 116MB dmg, drag-to-Applications layout). Welcome state was
+  cleared (prefs + WebKit localStorage) to re-test first-launch.
 
 ## What shipped this session
 
-1. **Torch-free runtime (PR #26)**: pose + court-detection person inference run on
-   `models/rallyclip_v0.3.1/yolov8n-pose-960-dynamic.onnx` via
-   `src/extraction/yolo_onnx_runner.py` (onnxruntime+numpy+cv2). 17/17 sweep samples
-   byte-equal vs torch; torch/ultralytics demoted to `[train]`; typed
-   UnsupportedOnnxOutputShapeError on non-pose heads. Results:
-   docs/onnx-pose-parity-plan.md.
-2. **System-webview shell (PR #27)**: pywebview (WKWebView/WebView2) replaces
-   QtWebEngine/PySide6; `gui/native_player.py` + QWebChannel bridge deleted (the
-   system webview plays H.264/HEVC natively; the frontend's HTML5 fallback was
-   already complete). Bundle 765MB → 266MB .app / 113MB zipped (v0.1.0 dmg: 558MB).
-   PyAV is now the only bundled FFmpeg.
+1. **App-data storage (PR #28)**: frozen builds keep user data in the OS
+   per-user app-data dir (`~/Library/Application Support/RallyClip` on macOS,
+   `%APPDATA%` on Windows, XDG on Linux) with a one-time `shutil.move`
+   migration from the v0.1.0 `~/RallyClip` location. Windows branch selected
+   via `sys.platform` (pathlib breaks if you monkeypatch `os.name`).
+2. **Viewer direct playback (PR #29)**: new `/api/library/<id>/source` route
+   (Range/206) streams the original file; WKWebView decodes H.264 natively.
+   Fixes the stuck-at-8s bug (WebM preview windows transcode at ~2.5× real
+   time and starved playback). Window pipeline remains as automatic fallback.
+   Review hardening: probe callbacks take a `directProbeSeq` ticket so stale
+   canplay/error/timeout handlers are inert after item switches.
+3. **Segment edit mode (PR #31)**: non-destructive point editing in the viewer
+   — drag trim handles (Photos-style, live scrub), add/delete point, Reset to
+   original. Edits live in `segments_edited.csv`; `segments.csv` is never
+   written; the edited copy wins for playback manifest, `/segments`, CSV
+   download, and lazy export (export.mp4 invalidated on edit/reset). Routes:
+   `PUT /api/library/<id>/segments`, `DELETE /api/library/<id>/segments/edits`.
+   Autosaves are serialized + generation-guarded so a stale PUT can't
+   resurrect a reset; reset refuses to delete the edited copy if the original
+   CSV is missing.
+4. **CoreML spike (PR #30, docs only)**: static 544×960 re-export of the pose
+   weights + CoreMLExecutionProvider (MLProgram, ALL) = 120.4 fps vs 15.6 fps
+   shipping CPU path (~7.7×), confident-det divergence 1.2e-4. Dynamic-axes
+   export blocks the ANE (that's why naive CoreML EP is only 1.2×). LSTM is
+   slower on CoreML — stays CPU. Verdict: no MLX rewrite. Scripts + results:
+   `docs/perf/coreml-spike/` (reproducible via `RALLYCLIP_SPIKE_SOURCE`).
 
 ## Next steps (in order)
 
-1. User merges #26 then #27; tag a release so release.yml (already updated) produces
-   the torch-free, Qt-free dmg. Release QA: WebView2 presence on older Win10;
-   confirm HTML5 playback suffices → then delete the gui/app.py playback-proxy
-   endpoints.
-2. Optional size follow-up: videoio-less OpenCV wheel (core+imgproc+calib3d+features2d)
-   kills cv2's 75MB direct-linked FFmpeg → app ~190MB. Build-infra chore, zero
-   algorithm risk.
-3. Backlog: training-quality-harness, macos-native-app-storage (see
-   ../RallyClip/feature_list.json), perf streaming loop (docs/perf/).
+1. **CoreML productionization** (feature `mlx-apple-silicon-backend`,
+   in_progress): static 544×960 export into the model bundle; opt-in provider
+   flag (CPU stays the byte-parity default); letterbox-pad fallback for
+   non-16:9; golden-verify static export vs bundled dynamic ONNX.
+2. After the user's manual QA: tag a release from main so release.yml ships
+   the storage-fix + direct-playback + edit-mode build.
+3. Distribution: Developer ID signing + notarization (user has an Apple dev
+   account — feature `macos-app-distribution`), then iOS/subscription track.
+4. Cleanup candidates: WebM preview-window pipeline + Qt-era proxy endpoints
+   once direct playback is QA-confirmed; welcome-screen quirk (frontend trusts
+   stale WebKit localStorage over server `welcome_seen: false`, script.js:311).
+5. Backlog: training-quality-harness, model retrain on all data, perf
+   streaming loop (docs/perf/).

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,7 +1,7 @@
 # REPO_MAP — RallyClip (worktree: RallyClip-perf; branch: see docs/PROGRESS.md)
 
-Built at commit `33eb13d` (2026-07-04). Staleness check:
-`git diff --stat 33eb13d.. -- src tests scripts configs .github pyproject.toml`
+Built at commit `42da683` (2026-07-05). Staleness check:
+`git diff --stat 42da683.. -- src tests scripts configs .github pyproject.toml`
 If that shows changes not reflected here, update this map in the same commit as your work.
 
 ## Container context (one level up)
@@ -37,7 +37,8 @@ dir is not a git repo; this table is the authoritative summary):
 - **Analysis pipeline behavior / segments wrong** → `src/rallyclip_engine/models.py` (AnalysisModel ABC + pipeline impls), `src/rallyclip_core/pipelines.py`, `models/rallyclip_v0.3.1/manifest.json`, then `src/rallyclip_core/intervals.py`.
 - **CLI** → `src/cli/main.py` (single file; `main()` at :337), `tests/test_cli_config_contract.py`, `tests/test_cli_json_output.py`.
 - **GUI/backend HTTP API** → `src/gui/app.py` (Flask, module-global config — see seams), `src/rallyclip_api/services.py`, `tests/test_api_route_contracts.py`, `tests/test_api_job_lifecycle.py`.
-- **Desktop shell / playback** → `src/gui/desktop.py` (pywebview shell), `src/rallyclip_core/playback.py`, `tests/test_native_playback.py` (server-side proxy/descriptor only; the Qt native player was deleted 2026-07-04).
+- **Desktop shell / playback** → `src/gui/desktop.py` (pywebview shell), `src/rallyclip_core/playback.py`, `tests/test_native_playback.py` (server-side proxy/descriptor only; the Qt native player was deleted 2026-07-04). Viewer streams `/api/library/<id>/source` directly (Range/206); WebM preview windows are the codec fallback.
+- **Segment edit mode** → `src/gui/app.py` (`PUT .../segments`, `DELETE .../segments/edits`), `src/rallyclip_core/library.py` (`resolve_segments`: `segments_edited.csv` wins, original never written), `src/rallyclip_core/intervals.py` (`write_point_intervals`), frontend `src/gui/frontend/script.js` (edit-mode section), e2e `tests/test_gui_playwright.py::test_ui_segment_edit_mode_*`.
 - **Pose extraction (ONNX runtime)** → `src/extraction/yolo_onnx_runner.py` + `src/extraction/pose_extractor.py` (dispatch on weights extension), `tests/test_yolo_onnx_runner.py`, `docs/onnx-pose-parity-plan.md`, `../YOLO-ONNX/scripts/parity_v8n_960.py`.
 - **Court detection** → `src/preprocessing/court_detector_impl.py`, `tests/test_court_detection_deterministic.py`, `tests/helpers/court_fixtures.py`; regen fixtures with `scripts/court_fixtures_gen.py`.
 - **Features/preprocessing (runtime)** → `src/features/feature_engineer.py`, `src/preprocessing/data_preprocessor.py`, contract tests `tests/test_runtime_*_contract.py`.


### PR DESCRIPTION
Docs-only. PROGRESS.md rewritten for this session, DECISIONS.md entries for #28/#29/#31 (the #30 spike entry landed with that PR), REPO_MAP.md staleness pointer + new seams (direct playback, segment edit mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af7zsfhk4MjRJRkN9xG6gq