### PR TITLE
Gapless point-to-point playback in the viewer

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -70,3 +70,52 @@ Format per entry: date — what / why / rejected alternative. Never rewrite old 
   re-export); NeuralNetwork-format CoreML (0.25 abs divergence — actually wrong);
   CPUAndNeuralEngine-only compute units (2x — ANE alone loses to ANE+GPU "ALL");
   accelerating the LSTM (measured slower on CoreML).
+
+## 2026-07-05 — Frozen-app data lives in the OS app-data dir (PR #28)
+
+- **What:** `gui.app._frozen_data_root()` puts packaged-build user data in
+  `~/Library/Application Support/RallyClip` (macOS) / `%APPDATA%` (Windows) /
+  XDG data home (Linux), with a one-time `shutil.move` migration from the
+  v0.1.0 `~/RallyClip` location. Windows is selected via `sys.platform`.
+- **Why:** dumping a data dir in `$HOME` violates platform conventions; the
+  migration keeps v0.1.0 users' libraries. `sys.platform` (not `os.name`)
+  because pathlib picks WindowsPath/PosixPath from `os.name` at instantiation —
+  monkeypatching it breaks every `Path()` in tests on Windows.
+- **Rejected:** `Path.rename` (EXDEV across filesystems — shutil.move falls
+  back to copy+delete); zero-arg lru_cache memoization (leaks state across
+  platform-monkeypatching tests for a handful of one-time stats).
+
+## 2026-07-05 — Viewer streams the source file directly (PR #29)
+
+- **What:** `/api/library/<id>/source` serves the saved match with
+  `send_file(conditional=True)` (Range/206); the frontend models it as one
+  full-length window so the existing source-time scheduler (seeks, point
+  skips, timeline) is unchanged. WebM preview windows remain the automatic
+  fallback (probe error or 10s timeout; probes are sequence-ticketed so stale
+  callbacks are inert).
+- **Why:** the stuck-at-first-8s bug: 8s VP8/WebM windows transcode at ~2.5×
+  real time (17–22s per window, file-mtime evidence + live WebKit repro), so
+  playback stalled at every boundary. The WebM pipeline only ever existed
+  because QtWebEngine's Chromium lacked H.264 — the system webview (PR #27)
+  decodes it natively.
+- **Rejected:** speeding up the transcode (still a transcode; still burns CPU
+  and disk); MSE path (permanently dormant, `canUseMsePreview()` false);
+  deleting the window pipeline immediately (kept as codec-fallback until
+  direct playback is QA-confirmed in the wild).
+
+## 2026-07-05 — Segment edits are a shadow CSV, never the original (PR #31)
+
+- **What:** viewer edit mode writes user point edits to `segments_edited.csv`;
+  the model-produced `segments.csv` is never modified. The edited copy wins
+  everywhere (`resolve_segments`: playback manifest, /segments, CSV download,
+  lazy export — export.mp4 invalidated on edit/reset). Reset deletes the copy;
+  it refuses if the original is missing (legacy items). Frontend autosaves are
+  serialized and generation-guarded (a stale PUT can't resurrect a reset).
+- **Why:** "Reset to original" must always be possible, so the original is a
+  read-only contract; a shadow file with precedence is the smallest mechanism
+  that gives every consumer the edited times without touching the analysis
+  output. All behavior stays `/api/*` HTTP per the architecture invariant.
+- **Rejected:** editing segments.csv in place with a backup copy (reversed
+  precedence is easier to corrupt — an interrupted write loses the original);
+  edits in meta.json (two sources of truth for point times); save-on-Done only
+  (drag sessions lose work on crash; autosave matches the iPhone-Photos model).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,37 +1,59 @@
 # PROGRESS — overwrite me at every session end
 
-_Last updated: 2026-07-04 (session: torch-free runtime + system-webview shell)._
+_Last updated: 2026-07-05 (session: storage fix + direct playback + segment edit mode + CoreML spike)._
 
 ## Repo state
 
-- Branch `feat/pywebview-shell` (stacked on `feat/onnx-pose-runner`), clean, pushed.
-- Open PRs, both CI-green (3 OS × test/e2e): **#26** torch-free ONNX runtime,
-  **#27** pywebview shell. Merge #26 first, then #27; the user merges.
-- Gates: fast suite 202 passed / 1 skipped; e2e 15 passed local; golden CLI parity
-  byte-equal (incl. from the frozen bundle and a torch-free venv).
+- `main` is the release line and everything is merged: **#28** app-data storage,
+  **#29** viewer direct playback, **#30** CoreML spike docs, **#31** segment edit
+  mode. No open PRs.
+- Gates: CI green 3 OS × test/e2e on every merged PR; smoke 33 passed;
+  playwright module 7/7 (includes a real mouse-drag edit-mode e2e).
+- User is manually QA-ing a fresh DMG built from the merged code
+  (266MB .app / 116MB dmg, drag-to-Applications layout). Welcome state was
+  cleared (prefs + WebKit localStorage) to re-test first-launch.
 
 ## What shipped this session
 
-1. **Torch-free runtime (PR #26)**: pose + court-detection person inference run on
-   `models/rallyclip_v0.3.1/yolov8n-pose-960-dynamic.onnx` via
-   `src/extraction/yolo_onnx_runner.py` (onnxruntime+numpy+cv2). 17/17 sweep samples
-   byte-equal vs torch; torch/ultralytics demoted to `[train]`; typed
-   UnsupportedOnnxOutputShapeError on non-pose heads. Results:
-   docs/onnx-pose-parity-plan.md.
-2. **System-webview shell (PR #27)**: pywebview (WKWebView/WebView2) replaces
-   QtWebEngine/PySide6; `gui/native_player.py` + QWebChannel bridge deleted (the
-   system webview plays H.264/HEVC natively; the frontend's HTML5 fallback was
-   already complete). Bundle 765MB → 266MB .app / 113MB zipped (v0.1.0 dmg: 558MB).
-   PyAV is now the only bundled FFmpeg.
+1. **App-data storage (PR #28)**: frozen builds keep user data in the OS
+   per-user app-data dir (`~/Library/Application Support/RallyClip` on macOS,
+   `%APPDATA%` on Windows, XDG on Linux) with a one-time `shutil.move`
+   migration from the v0.1.0 `~/RallyClip` location. Windows branch selected
+   via `sys.platform` (pathlib breaks if you monkeypatch `os.name`).
+2. **Viewer direct playback (PR #29)**: new `/api/library/<id>/source` route
+   (Range/206) streams the original file; WKWebView decodes H.264 natively.
+   Fixes the stuck-at-8s bug (WebM preview windows transcode at ~2.5× real
+   time and starved playback). Window pipeline remains as automatic fallback.
+   Review hardening: probe callbacks take a `directProbeSeq` ticket so stale
+   canplay/error/timeout handlers are inert after item switches.
+3. **Segment edit mode (PR #31)**: non-destructive point editing in the viewer
+   — drag trim handles (Photos-style, live scrub), add/delete point, Reset to
+   original. Edits live in `segments_edited.csv`; `segments.csv` is never
+   written; the edited copy wins for playback manifest, `/segments`, CSV
+   download, and lazy export (export.mp4 invalidated on edit/reset). Routes:
+   `PUT /api/library/<id>/segments`, `DELETE /api/library/<id>/segments/edits`.
+   Autosaves are serialized + generation-guarded so a stale PUT can't
+   resurrect a reset; reset refuses to delete the edited copy if the original
+   CSV is missing.
+4. **CoreML spike (PR #30, docs only)**: static 544×960 re-export of the pose
+   weights + CoreMLExecutionProvider (MLProgram, ALL) = 120.4 fps vs 15.6 fps
+   shipping CPU path (~7.7×), confident-det divergence 1.2e-4. Dynamic-axes
+   export blocks the ANE (that's why naive CoreML EP is only 1.2×). LSTM is
+   slower on CoreML — stays CPU. Verdict: no MLX rewrite. Scripts + results:
+   `docs/perf/coreml-spike/` (reproducible via `RALLYCLIP_SPIKE_SOURCE`).
 
 ## Next steps (in order)
 
-1. User merges #26 then #27; tag a release so release.yml (already updated) produces
-   the torch-free, Qt-free dmg. Release QA: WebView2 presence on older Win10;
-   confirm HTML5 playback suffices → then delete the gui/app.py playback-proxy
-   endpoints.
-2. Optional size follow-up: videoio-less OpenCV wheel (core+imgproc+calib3d+features2d)
-   kills cv2's 75MB direct-linked FFmpeg → app ~190MB. Build-infra chore, zero
-   algorithm risk.
-3. Backlog: training-quality-harness, macos-native-app-storage (see
-   ../RallyClip/feature_list.json), perf streaming loop (docs/perf/).
+1. **CoreML productionization** (feature `mlx-apple-silicon-backend`,
+   in_progress): static 544×960 export into the model bundle; opt-in provider
+   flag (CPU stays the byte-parity default); letterbox-pad fallback for
+   non-16:9; golden-verify static export vs bundled dynamic ONNX.
+2. After the user's manual QA: tag a release from main so release.yml ships
+   the storage-fix + direct-playback + edit-mode build.
+3. Distribution: Developer ID signing + notarization (user has an Apple dev
+   account — feature `macos-app-distribution`), then iOS/subscription track.
+4. Cleanup candidates: WebM preview-window pipeline + Qt-era proxy endpoints
+   once direct playback is QA-confirmed; welcome-screen quirk (frontend trusts
+   stale WebKit localStorage over server `welcome_seen: false`, script.js:311).
+5. Backlog: training-quality-harness, model retrain on all data, perf
+   streaming loop (docs/perf/).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -42,18 +42,31 @@ _Last updated: 2026-07-05 (session: storage fix + direct playback + segment edit
    slower on CoreML — stays CPU. Verdict: no MLX rewrite. Scripts + results:
    `docs/perf/coreml-spike/` (reproducible via `RALLYCLIP_SPIKE_SOURCE`).
 
+## QA feedback (2026-07-05, user ran the DMG)
+
+- **Gaps between plays**: point-to-point playback pauses (audible audio
+  dropout) instead of being continuous → new feature
+  `continuous-playback-no-gaps` (direct-playback seek path).
+- **Edit mode**: short points are hard to grab on the full-match timeline;
+  wants timeline zoom → feature `edit-mode-timeline-zoom`, explicitly
+  DEFERRED by the user ("skip that for now, editing is lower priority").
+- Re-confirmed priorities: model retrain on all data + inference speedup
+  (CoreML productionization); "we eventually want to make the app soon".
+
 ## Next steps (in order)
 
-1. **CoreML productionization** (feature `mlx-apple-silicon-backend`,
+1. **Continuous playback** (feature `continuous-playback-no-gaps`): eliminate
+   the inter-point gap/audio dropout in the viewer's point-only playback.
+2. **CoreML productionization** (feature `mlx-apple-silicon-backend`,
    in_progress): static 544×960 export into the model bundle; opt-in provider
    flag (CPU stays the byte-parity default); letterbox-pad fallback for
    non-16:9; golden-verify static export vs bundled dynamic ONNX.
-2. After the user's manual QA: tag a release from main so release.yml ships
-   the storage-fix + direct-playback + edit-mode build.
-3. Distribution: Developer ID signing + notarization (user has an Apple dev
-   account — feature `macos-app-distribution`), then iOS/subscription track.
-4. Cleanup candidates: WebM preview-window pipeline + Qt-era proxy endpoints
+3. **Model retrain on all data** (feature `model-retrain-full-data`) — user
+   re-confirmed 2026-07-05.
+4. Tag a release from main once QA issues are addressed; then Developer ID
+   signing + notarization (`macos-app-distribution`), then iOS/subscription.
+5. Cleanup candidates: WebM preview-window pipeline + Qt-era proxy endpoints
    once direct playback is QA-confirmed; welcome-screen quirk (frontend trusts
    stale WebKit localStorage over server `welcome_seen: false`, script.js:311).
-5. Backlog: training-quality-harness, model retrain on all data, perf
-   streaming loop (docs/perf/).
+6. Deferred by user: `edit-mode-timeline-zoom`. Backlog:
+   training-quality-harness, perf streaming loop (docs/perf/).

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,7 +1,7 @@
 # REPO_MAP — RallyClip (worktree: RallyClip-perf; branch: see docs/PROGRESS.md)
 
-Built at commit `33eb13d` (2026-07-04). Staleness check:
-`git diff --stat 33eb13d.. -- src tests scripts configs .github pyproject.toml`
+Built at commit `42da683` (2026-07-05). Staleness check:
+`git diff --stat 42da683.. -- src tests scripts configs .github pyproject.toml`
 If that shows changes not reflected here, update this map in the same commit as your work.
 
 ## Container context (one level up)
@@ -37,7 +37,8 @@ dir is not a git repo; this table is the authoritative summary):
 - **Analysis pipeline behavior / segments wrong** → `src/rallyclip_engine/models.py` (AnalysisModel ABC + pipeline impls), `src/rallyclip_core/pipelines.py`, `models/rallyclip_v0.3.1/manifest.json`, then `src/rallyclip_core/intervals.py`.
 - **CLI** → `src/cli/main.py` (single file; `main()` at :337), `tests/test_cli_config_contract.py`, `tests/test_cli_json_output.py`.
 - **GUI/backend HTTP API** → `src/gui/app.py` (Flask, module-global config — see seams), `src/rallyclip_api/services.py`, `tests/test_api_route_contracts.py`, `tests/test_api_job_lifecycle.py`.
-- **Desktop shell / playback** → `src/gui/desktop.py` (pywebview shell), `src/rallyclip_core/playback.py`, `tests/test_native_playback.py` (server-side proxy/descriptor only; the Qt native player was deleted 2026-07-04).
+- **Desktop shell / playback** → `src/gui/desktop.py` (pywebview shell), `src/rallyclip_core/playback.py`, `tests/test_native_playback.py` (server-side proxy/descriptor only; the Qt native player was deleted 2026-07-04). Viewer streams `/api/library/<id>/source` directly (Range/206); WebM preview windows are the codec fallback.
+- **Segment edit mode** → `src/gui/app.py` (`PUT .../segments`, `DELETE .../segments/edits`), `src/rallyclip_core/library.py` (`resolve_segments`: `segments_edited.csv` wins, original never written), `src/rallyclip_core/intervals.py` (`write_point_intervals`), frontend `src/gui/frontend/script.js` (edit-mode section), e2e `tests/test_gui_playwright.py::test_ui_segment_edit_mode_*`.
 - **Pose extraction (ONNX runtime)** → `src/extraction/yolo_onnx_runner.py` + `src/extraction/pose_extractor.py` (dispatch on weights extension), `tests/test_yolo_onnx_runner.py`, `docs/onnx-pose-parity-plan.md`, `../YOLO-ONNX/scripts/parity_v8n_960.py`.
 - **Court detection** → `src/preprocessing/court_detector_impl.py`, `tests/test_court_detection_deterministic.py`, `tests/helpers/court_fixtures.py`; regen fixtures with `scripts/court_fixtures_gen.py`.
 - **Features/preprocessing (runtime)** → `src/features/feature_engineer.py`, `src/preprocessing/data_preprocessor.py`, contract tests `tests/test_runtime_*_contract.py`.

--- a/scripts/make_smoke_clip.py
+++ b/scripts/make_smoke_clip.py
@@ -20,11 +20,17 @@ import numpy as np
 WIDTH, HEIGHT, FPS = 1280, 720, 10
 
 
-def make_clip(out_path: Path, duration_s: float = 30.0, width: int = WIDTH, height: int = HEIGHT) -> None:
+def make_clip(
+    out_path: Path,
+    duration_s: float = 30.0,
+    width: int = WIDTH,
+    height: int = HEIGHT,
+    codec: str = "mpeg4",
+) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     total_frames = int(duration_s * FPS)
     with av.open(str(out_path), mode="w") as container:
-        stream = container.add_stream("mpeg4", rate=FPS)
+        stream = container.add_stream(codec, rate=FPS)
         stream.width = width
         stream.height = height
         stream.pix_fmt = "yuv420p"

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -978,6 +978,19 @@ class RallyClipApp {
         standby.load();
     }
 
+    shouldWaitForDirectStandby(nextPointIndex) {
+        // The timeupdate advance fires ~30-80ms before the watcher's gate; if
+        // the standby is still loading at that moment, a cold seek here would
+        // waste an almost-ready swap. Give the standby a short grace window
+        // (playing ~0.3s into the dead gap after the point) before giving up.
+        if (!this.directPlayback) return false;
+        const state = this.directStandby;
+        if (!state || state.pointIndex !== nextPointIndex) return false;
+        const end = Number(this.activePlaybackSegment?.end);
+        if (!Number.isFinite(end)) return false;
+        return this.getViewerSourceTime() <= end + 0.3;
+    }
+
     tryDirectStandbySwap(nextPointIndex) {
         if (!this.directPlayback) return false;
         const state = this.directStandby;
@@ -2609,6 +2622,7 @@ class RallyClipApp {
         const nextPointIndex = this.activePlaybackSegment.nextPointIndex;
         if (Number.isInteger(nextPointIndex) && this.pointIntervals[nextPointIndex]) {
             if (this.tryDirectStandbySwap(nextPointIndex)) return;
+            if (this.shouldWaitForDirectStandby(nextPointIndex)) return;
             this.seekViewerToSourceTime(this.pointIntervals[nextPointIndex].start, true);
             return;
         }

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -52,6 +52,9 @@ class RallyClipApp {
         this.directPlayback = false;
         this.directProbeInProgress = false;
         this.directProbeSeq = 0;
+        this.directStandby = null;
+        this.directWatcherActive = false;
+        this.directStandbyLeadSeconds = 5;
         this.editMode = false;
         this.editSelectedIndex = -1;
         this.editDrag = null;
@@ -276,7 +279,9 @@ class RallyClipApp {
             if (video === this.matchVideo) this.handleViewerTimeUpdate();
         });
         video.addEventListener("play", () => {
-            if (video === this.matchVideo) this.updateViewerControls();
+            if (video !== this.matchVideo) return;
+            this.updateViewerControls();
+            if (this.directPlayback) this.startDirectSegmentWatcher();
         });
         video.addEventListener("pause", () => {
             if (video === this.matchVideo) this.updateViewerControls();
@@ -529,6 +534,7 @@ class RallyClipApp {
             this.resetMsePreview();
             this.resetViewerVideos();
             this.directPlayback = false;
+            this.directStandby = null;
             this.viewingItemId = null;
             this.pointIntervals = [];
             this.lastViewerTime = null;
@@ -566,6 +572,7 @@ class RallyClipApp {
 
     resetViewerVideos() {
         this.resetMsePreview();
+        this.directStandby = null;
         this.clearVideoElement(this.primaryMatchVideo);
         this.clearVideoElement(this.secondaryMatchVideo);
         this.matchVideo = this.primaryMatchVideo;
@@ -875,6 +882,7 @@ class RallyClipApp {
                 this.hidePreviewLoading();
                 this.updateViewerControls();
                 if (autoplay) this.startViewerPlayback();
+                this.startDirectSegmentWatcher();
                 settle(true);
             };
             const onError = () => {
@@ -893,6 +901,108 @@ class RallyClipApp {
             video.dataset.previewUrl = sourceUrl;
             video.load();
         });
+    }
+
+    startDirectSegmentWatcher() {
+        // timeupdate fires ~4x/s, so relying on it alone overshoots a point's
+        // end by up to 250ms before the jump even starts. While direct
+        // playback is rolling, poll at frame granularity instead; the loop
+        // parks itself on pause and is restarted by the play handler.
+        if (this.directWatcherActive) return;
+        this.directWatcherActive = true;
+        const tick = () => {
+            if (!this.directPlayback || !this.viewingItemId || !this.matchVideo?.src || this.matchVideo.paused) {
+                this.directWatcherActive = false;
+                return;
+            }
+            requestAnimationFrame(tick);
+            if (this.viewerSeekInProgress || this.editMode) return;
+            const segment = this.activePlaybackSegment;
+            const end = Number(segment?.end);
+            if (!segment || !Number.isFinite(end)) return;
+            const t = this.getViewerSourceTime();
+            if (Number.isInteger(segment.nextPointIndex) && end - t < this.directStandbyLeadSeconds) {
+                this.prepareDirectStandby(segment.nextPointIndex);
+            }
+            if (t >= end - 0.05) this.advanceAfterActivePlaybackSegment();
+        };
+        requestAnimationFrame(tick);
+    }
+
+    prepareDirectStandby(nextPointIndex) {
+        // Pre-seek the idle second <video> to the next point's start while the
+        // current point is still playing, so the boundary jump is an element
+        // swap instead of a cold seek (which stalls audio for the range fetch
+        // + keyframe decode).
+        if (!this.directPlayback) return;
+        const next = this.pointIntervals[nextPointIndex];
+        const standby = this.matchVideoBuffer;
+        if (!next || !standby || standby === this.matchVideo) return;
+        const current = this.directStandby;
+        if (current && current.video === standby && current.pointIndex === nextPointIndex && current.target === next.start) return;
+        const sourceUrl = this.matchVideo.dataset.previewUrl;
+        if (!sourceUrl) return;
+        const state = { video: standby, pointIndex: nextPointIndex, target: next.start, ready: false };
+        this.directStandby = state;
+        const onSeeked = () => {
+            standby.removeEventListener("seeked", onSeeked);
+            if (this.directStandby === state) state.ready = true;
+        };
+        const seekStandby = () => {
+            if (this.directStandby !== state || standby === this.matchVideo) return;
+            standby.dataset.windowStart = "0";
+            standby.dataset.windowDuration = this.matchVideo.dataset.windowDuration || "0";
+            standby.addEventListener("seeked", onSeeked);
+            standby.pause();
+            standby.currentTime = state.target;
+        };
+        if (standby.dataset.previewUrl === sourceUrl && standby.readyState >= 1) {
+            seekStandby();
+            return;
+        }
+        standby.addEventListener("loadedmetadata", seekStandby, { once: true });
+        standby.src = sourceUrl;
+        standby.dataset.previewUrl = sourceUrl;
+        standby.load();
+    }
+
+    tryDirectStandbySwap(nextPointIndex) {
+        if (!this.directPlayback) return false;
+        const state = this.directStandby;
+        if (!state || state.pointIndex !== nextPointIndex || !state.ready) return false;
+        const standby = state.video;
+        if (standby !== this.matchVideoBuffer || standby.readyState < 2) return false;
+        const point = this.pointIntervals[nextPointIndex];
+        // Edits can rewrite pointIntervals after the standby was prepared;
+        // a mismatched target means the pre-seek landed in the wrong place.
+        if (!point || point.start !== state.target || Math.abs(standby.currentTime - state.target) > 0.75) {
+            this.directStandby = null;
+            return false;
+        }
+        const previous = this.matchVideo;
+        this.directStandby = null;
+        standby.muted = previous.muted;
+        standby.volume = previous.volume;
+        const playPromise = standby.play();
+        previous.pause();
+        this.matchVideo = standby;
+        this.matchVideoBuffer = previous;
+        standby.classList.add("is-active");
+        standby.classList.remove("is-outgoing");
+        standby.tabIndex = 0;
+        previous.classList.remove("is-active");
+        previous.tabIndex = -1;
+        this.setPlaybackSegmentForSourceTime(state.target);
+        this.lastViewerTime = state.target;
+        this.updateViewerTimeline(state.target);
+        this.updateViewerControls();
+        this.startDirectSegmentWatcher();
+        if (playPromise?.catch) {
+            playPromise.catch(() => {
+                if (this.matchVideo === standby) this.seekViewerToSourceTime(state.target, true);
+            });
+        }
+        return true;
     }
 
     clearPreviewPoll() {
@@ -2426,7 +2536,9 @@ class RallyClipApp {
             const target = this.lastViewerTime ?? this.getViewerSourceTime();
             const wasPlaying = !this.matchVideo.paused;
             this.directPlayback = false;
+            this.directStandby = null;
             this.clearVideoElement(this.matchVideo);
+            this.clearVideoElement(this.matchVideoBuffer);
             this.loadPreviewWindowAt(target, wasPlaying);
             return;
         }
@@ -2482,6 +2594,7 @@ class RallyClipApp {
         if (!this.activePlaybackSegment || this.previewLoadInProgress) return;
         const nextPointIndex = this.activePlaybackSegment.nextPointIndex;
         if (Number.isInteger(nextPointIndex) && this.pointIntervals[nextPointIndex]) {
+            if (this.tryDirectStandbySwap(nextPointIndex)) return;
             this.seekViewerToSourceTime(this.pointIntervals[nextPointIndex].start, true);
             return;
         }

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -884,8 +884,10 @@ class RallyClipApp {
                 this.updateViewerTimeline(target);
                 this.hidePreviewLoading();
                 this.updateViewerControls();
-                if (autoplay) this.startViewerPlayback();
-                this.startDirectSegmentWatcher();
+                if (autoplay) {
+                    this.startViewerPlayback();
+                    this.startDirectSegmentWatcher();
+                }
                 settle(true);
             };
             const onError = () => {
@@ -959,8 +961,15 @@ class RallyClipApp {
             standby.pause();
             standby.currentTime = state.target;
         };
-        if (standby.dataset.previewUrl === sourceUrl && standby.readyState >= 1) {
-            seekStandby();
+        if (standby.dataset.previewUrl === sourceUrl) {
+            if (standby.readyState >= 1) {
+                seekStandby();
+                return;
+            }
+            // Same source still loading (re-entered during a rapid point
+            // change): wait on the in-flight load rather than resetting it
+            // with another src/load(), which restarts the HTTP fetch.
+            standby.addEventListener("loadedmetadata", seekStandby, { once: true });
             return;
         }
         standby.addEventListener("loadedmetadata", seekStandby, { once: true });

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -997,8 +997,8 @@ class RallyClipApp {
         this.directStandby = null;
         standby.muted = previous.muted;
         standby.volume = previous.volume;
-        const playPromise = standby.play();
         previous.pause();
+        const playPromise = standby.play();
         this.matchVideo = standby;
         this.matchVideoBuffer = previous;
         standby.classList.add("is-active");

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -987,7 +987,9 @@ class RallyClipApp {
         const point = this.pointIntervals[nextPointIndex];
         // Edits can rewrite pointIntervals after the standby was prepared;
         // a mismatched target means the pre-seek landed in the wrong place.
-        if (!point || point.start !== state.target || Math.abs(standby.currentTime - state.target) > 0.75) {
+        // One-sided tolerance: forward overshoot stays inside the point, but a
+        // backward miss would briefly play inter-point gap content.
+        if (!point || point.start !== state.target || standby.currentTime < state.target - 0.1 || standby.currentTime > state.target + 0.75) {
             this.directStandby = null;
             return false;
         }

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -54,7 +54,10 @@ class RallyClipApp {
         this.directProbeSeq = 0;
         this.directStandby = null;
         this.directWatcherActive = false;
-        this.directStandbyLeadSeconds = 5;
+        // Pre-seek the standby well before the boundary: extra lead is cheap
+        // (the element just buffers ahead) and buys headroom on slow disks so
+        // the swap never has to fall back to a cold seek mid-play.
+        this.directStandbyLeadSeconds = 8;
         this.editMode = false;
         this.editSelectedIndex = -1;
         this.editDrag = null;

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -58,6 +58,11 @@ class RallyClipApp {
         // (the element just buffers ahead) and buys headroom on slow disks so
         // the swap never has to fall back to a cold seek mid-play.
         this.directStandbyLeadSeconds = 8;
+        // Start the standby rolling (muted, hidden) this long before the
+        // boundary: play() on a cold element takes WKWebView ~100ms to spin
+        // up the audio pipeline, which is audible; unmuting a rolling
+        // element is not.
+        this.directWarmupSeconds = 0.5;
         this.editMode = false;
         this.editSelectedIndex = -1;
         this.editDrag = null;
@@ -287,7 +292,9 @@ class RallyClipApp {
             if (this.directPlayback) this.startDirectSegmentWatcher();
         });
         video.addEventListener("pause", () => {
-            if (video === this.matchVideo) this.updateViewerControls();
+            if (video !== this.matchVideo) return;
+            this.updateViewerControls();
+            this.cancelDirectStandbyWarmup();
         });
         video.addEventListener("loadedmetadata", () => {
             if (video === this.matchVideo) this.updateViewerControls();
@@ -928,6 +935,13 @@ class RallyClipApp {
             const t = this.getViewerSourceTime();
             if (Number.isInteger(segment.nextPointIndex) && end - t < this.directStandbyLeadSeconds) {
                 this.prepareDirectStandby(segment.nextPointIndex);
+                const state = this.directStandby;
+                if (
+                    state && state.pointIndex === segment.nextPointIndex
+                    && state.ready && !state.warm && end - t <= this.directWarmupSeconds
+                ) {
+                    this.warmDirectStandby(state, end - t);
+                }
             }
             if (t >= end - 0.05) this.advanceAfterActivePlaybackSegment();
         };
@@ -947,7 +961,7 @@ class RallyClipApp {
         if (current && current.video === standby && current.pointIndex === nextPointIndex && current.target === next.start) return;
         const sourceUrl = this.matchVideo.dataset.previewUrl;
         if (!sourceUrl) return;
-        const state = { video: standby, pointIndex: nextPointIndex, target: next.start, ready: false };
+        const state = { video: standby, pointIndex: nextPointIndex, target: next.start, ready: false, warm: false };
         this.directStandby = state;
         const onSeeked = () => {
             standby.removeEventListener("seeked", onSeeked);
@@ -978,6 +992,35 @@ class RallyClipApp {
         standby.load();
     }
 
+    warmDirectStandby(state, remainingSeconds) {
+        // Roll the standby muted+hidden through the tail of the gap so it
+        // arrives at the point start exactly when the boundary hits; the swap
+        // then only unmutes an already-playing element.
+        const standby = state.video;
+        if (!standby || standby === this.matchVideo || standby !== this.matchVideoBuffer) return;
+        state.warm = true;
+        standby.muted = true;
+        const preRoll = Math.max(0.05, Math.min(this.directWarmupSeconds, remainingSeconds));
+        standby.currentTime = Math.max(0, state.target - preRoll);
+        const playPromise = standby.play();
+        if (playPromise?.catch) {
+            playPromise.catch(() => {
+                if (this.directStandby === state) state.warm = false;
+            });
+        }
+    }
+
+    cancelDirectStandbyWarmup() {
+        // A warm standby is rolling; if playback stops being about to cross
+        // the boundary (pause, manual seek, edit mode), stop it and forget it
+        // so the watcher can re-prepare cleanly on resume.
+        const state = this.directStandby;
+        if (!state?.warm) return;
+        const standby = state.video;
+        if (standby && standby !== this.matchVideo) standby.pause();
+        this.directStandby = null;
+    }
+
     shouldWaitForDirectStandby(nextPointIndex) {
         // The timeupdate advance fires ~30-80ms before the watcher's gate; if
         // the standby is still loading at that moment, a cold seek here would
@@ -1002,15 +1045,23 @@ class RallyClipApp {
         // a mismatched target means the pre-seek landed in the wrong place.
         // One-sided tolerance: forward overshoot stays inside the point, but a
         // backward miss would briefly play inter-point gap content.
-        if (!point || point.start !== state.target || standby.currentTime < state.target - 0.1 || standby.currentTime > state.target + 0.75) {
+        // A warm standby is rolling toward the target through the (dead,
+        // muted, hidden) gap tail, so being early is expected; a cold one
+        // must sit at the target already.
+        const backTolerance = state.warm ? this.directWarmupSeconds + 0.25 : 0.1;
+        if (!point || point.start !== state.target || standby.currentTime < state.target - backTolerance || standby.currentTime > state.target + 0.75) {
+            if (state.warm) standby.pause();
             this.directStandby = null;
             return false;
         }
         const previous = this.matchVideo;
         this.directStandby = null;
-        standby.muted = previous.muted;
         standby.volume = previous.volume;
         previous.pause();
+        standby.muted = previous.muted;
+        // On a warm (already-rolling) standby play() resolves immediately;
+        // on a cold one it starts playback — either way the catch below
+        // falls back to a seek if the engine refuses.
         const playPromise = standby.play();
         this.matchVideo = standby;
         this.matchVideoBuffer = previous;
@@ -2161,6 +2212,7 @@ class RallyClipApp {
             console.warn("Could not refresh point times before editing", err);
         }
         if (this.viewingItemId !== itemId) return;
+        this.cancelDirectStandbyWarmup();
         this.editMode = true;
         this.editSelectedIndex = this.pointIntervals.length ? 0 : -1;
         if (this.viewerHasVideo()) this.matchVideo.pause();
@@ -2509,6 +2561,7 @@ class RallyClipApp {
             return;
         }
         if (this.directPlayback && this.matchVideo.src) {
+            this.cancelDirectStandbyWarmup();
             this.matchVideo.currentTime = target;
             this.lastViewerTime = target;
             this.updateViewerTimeline(target);

--- a/src/gui/frontend/styles.css
+++ b/src/gui/frontend/styles.css
@@ -634,11 +634,13 @@ select {
     display: none;
 }
 
+/* Sits above the range input (z2) so the neon bars read on top of the white
+   track; pointer-events none keeps the input scrubbable through it. */
 .viewer-point-track {
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 1;
+    z-index: 3;
 }
 
 .viewer-point-segment {
@@ -648,7 +650,8 @@ select {
     height: 0.5rem;
     border-radius: 999px;
     background: var(--tennis);
-    opacity: 0.92;
+    border: 1px solid rgba(0, 0, 0, 0.85);
+    box-sizing: border-box;
     box-shadow: 0 0 8px rgba(204, 255, 0, 0.35);
 }
 

--- a/src/gui/frontend/styles.css
+++ b/src/gui/frontend/styles.css
@@ -635,10 +635,25 @@ select {
 }
 
 .viewer-point-track {
-    display: none;
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
 }
 
 .viewer-point-segment {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 0.5rem;
+    border-radius: 999px;
+    background: var(--tennis);
+    opacity: 0.92;
+    box-shadow: 0 0 8px rgba(204, 255, 0, 0.35);
+}
+
+/* Edit mode draws its own draggable segments on top; hide the static bars. */
+.viewer-video-wrap.is-editing .viewer-point-track {
     display: none;
 }
 
@@ -646,6 +661,7 @@ select {
     appearance: none;
     -webkit-appearance: none;
     position: relative;
+    z-index: 2;
     width: 100%;
     height: 0.75rem;
     margin: 0;
@@ -659,8 +675,8 @@ select {
     border-radius: 999px;
     background: linear-gradient(
         to right,
-        var(--tennis) 0 var(--viewer-progress, 0%),
-        rgba(255, 255, 255, 0.34) var(--viewer-progress, 0%) 100%
+        rgba(255, 255, 255, 0.95) 0 var(--viewer-progress, 0%),
+        rgba(255, 255, 255, 0.3) var(--viewer-progress, 0%) 100%
     );
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
 }
@@ -679,14 +695,14 @@ select {
 .viewer-seek-wrap input[type="range"]::-moz-range-track {
     height: 0.32rem;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.34);
+    background: rgba(255, 255, 255, 0.3);
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
 }
 
 .viewer-seek-wrap input[type="range"]::-moz-range-progress {
     height: 0.32rem;
     border-radius: 999px;
-    background: var(--tennis);
+    background: rgba(255, 255, 255, 0.95);
 }
 
 .viewer-seek-wrap input[type="range"]::-moz-range-thumb {

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -153,16 +153,22 @@ def _fabricate_direct_playback_item() -> str:
     H.264 in the shipped app. Small frame keeps the VP9 encode fast; the
     viewer has no resolution minimum (only the analysis pipeline does)."""
     import json
+    import shutil
     import time
     import uuid
 
+    import av
     from gui import app as gui_app
     from make_smoke_clip import make_clip
 
     item_id = f"20990101-000000-{uuid.uuid4().hex[:6]}"
     item_dir = Path(gui_app.LIBRARY_DIR) / item_id
     item_dir.mkdir(parents=True, exist_ok=True)
-    make_clip(item_dir / "source.mp4", duration_s=8.0, width=320, height=180, codec="libvpx-vp9")
+    try:
+        make_clip(item_dir / "source.mp4", duration_s=8.0, width=320, height=180, codec="libvpx-vp9")
+    except (av.FFmpegError, ValueError) as exc:  # older FFmpeg builds lack vp09-in-mp4 muxing
+        shutil.rmtree(item_dir, ignore_errors=True)
+        pytest.skip(f"PyAV build cannot encode VP9-in-MP4: {exc}")
     (item_dir / "segments.csv").write_text("start_time,end_time\n1.0,2.0\n4.0,5.0\n", encoding="utf-8")
     (item_dir / "thumb.jpg").write_bytes(b"\xff\xd8\xff\xe0fake")
     (item_dir / "meta.json").write_text(

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -762,7 +762,7 @@ def test_ui_direct_playback_swaps_to_preseeked_standby_between_points(page: Page
     assert after["direct"] is True
     assert after["paused"] is False
     assert after["windowStart"] == 0
-    assert 3.9 <= after["time"] <= 5.6
+    assert 3.9 <= after["time"] <= 5.1
 
 
 def test_ui_segment_edit_mode_trims_adds_deletes_and_resets(page: Page, ui_backend: BackendClient):

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -310,6 +310,9 @@ def test_ui_viewer_uses_source_timeline_scheduler(page: Page, ui_backend: Backen
     assert startup["points"] == [{"start": 1, "end": 2}, {"start": 4, "end": 5}]
     assert startup["seekValue"] == pytest.approx(1.0, abs=0.2)
     assert startup["pointMarkers"] == 2
+    # The markers must actually render (they shipped display:none for a while
+    # after the Qt-native player, which drew its own, was deleted).
+    expect(page.locator(".viewer-point-segment").first).to_be_visible()
 
     scheduler = page.evaluate(
         """() => {

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -163,21 +163,24 @@ def _fabricate_direct_playback_item() -> str:
 
     item_id = f"20990101-000000-{uuid.uuid4().hex[:6]}"
     item_dir = Path(gui_app.LIBRARY_DIR) / item_id
-    item_dir.mkdir(parents=True, exist_ok=True)
     try:
+        item_dir.mkdir(parents=True, exist_ok=True)
         make_clip(item_dir / "source.mp4", duration_s=8.0, width=320, height=180, codec="libvpx-vp9")
+        (item_dir / "segments.csv").write_text("start_time,end_time\n1.0,2.0\n4.0,5.0\n", encoding="utf-8")
+        (item_dir / "thumb.jpg").write_bytes(b"\xff\xd8\xff\xe0fake")
+        (item_dir / "meta.json").write_text(
+            json.dumps({
+                "id": item_id, "name": "Direct Playback Match", "created": "2099-01-01T00:00:00",
+                "created_ts": time.time(), "duration_s": 8.0, "point_duration_s": 2.0, "n_segments": 2,
+            }),
+            encoding="utf-8",
+        )
     except (av.FFmpegError, ValueError) as exc:  # older FFmpeg builds lack vp09-in-mp4 muxing
         shutil.rmtree(item_dir, ignore_errors=True)
         pytest.skip(f"PyAV build cannot encode VP9-in-MP4: {exc}")
-    (item_dir / "segments.csv").write_text("start_time,end_time\n1.0,2.0\n4.0,5.0\n", encoding="utf-8")
-    (item_dir / "thumb.jpg").write_bytes(b"\xff\xd8\xff\xe0fake")
-    (item_dir / "meta.json").write_text(
-        json.dumps({
-            "id": item_id, "name": "Direct Playback Match", "created": "2099-01-01T00:00:00",
-            "created_ts": time.time(), "duration_s": 8.0, "point_duration_s": 2.0, "n_segments": 2,
-        }),
-        encoding="utf-8",
-    )
+    except BaseException:  # never leave a half-built item in the shared library dir
+        shutil.rmtree(item_dir, ignore_errors=True)
+        raise
     return item_id
 
 

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -143,6 +143,38 @@ def _fabricate_viewer_item() -> str:
     return item_id
 
 
+def _fabricate_direct_playback_item() -> str:
+    """Library item whose source headless Chromium can decode natively.
+
+    The mpeg4 smoke fixture never passes the direct-playback probe in
+    Chromium, so the /source path only ever runs as a fallback-skipped branch
+    here. VP9 in an MP4 container is a legal combination Chromium plays,
+    letting this suite exercise direct playback the way WKWebView exercises
+    H.264 in the shipped app. Small frame keeps the VP9 encode fast; the
+    viewer has no resolution minimum (only the analysis pipeline does)."""
+    import json
+    import time
+    import uuid
+
+    from gui import app as gui_app
+    from make_smoke_clip import make_clip
+
+    item_id = f"20990101-000000-{uuid.uuid4().hex[:6]}"
+    item_dir = Path(gui_app.LIBRARY_DIR) / item_id
+    item_dir.mkdir(parents=True, exist_ok=True)
+    make_clip(item_dir / "source.mp4", duration_s=8.0, width=320, height=180, codec="libvpx-vp9")
+    (item_dir / "segments.csv").write_text("start_time,end_time\n1.0,2.0\n4.0,5.0\n", encoding="utf-8")
+    (item_dir / "thumb.jpg").write_bytes(b"\xff\xd8\xff\xe0fake")
+    (item_dir / "meta.json").write_text(
+        json.dumps({
+            "id": item_id, "name": "Direct Playback Match", "created": "2099-01-01T00:00:00",
+            "created_ts": time.time(), "duration_s": 8.0, "point_duration_s": 2.0, "n_segments": 2,
+        }),
+        encoding="utf-8",
+    )
+    return item_id
+
+
 def _open_to_library(page: Page, base_url: str) -> None:
     """Land on the library view, dismissing the welcome screen if it shows.
 
@@ -675,6 +707,56 @@ def test_ui_viewer_uses_source_timeline_scheduler(page: Page, ui_backend: Backen
         }"""
     )
     assert timeline_config_preserves_time == {"value": 42.5, "current": "0:42", "duration": "2:00"}
+
+
+def test_ui_direct_playback_swaps_to_preseeked_standby_between_points(page: Page, ui_backend: BackendClient):
+    """Continuous playback: crossing a point boundary in direct playback must
+    swap to the pre-seeked standby <video>, not cold-seek the playing element
+    (a cold seek stalls audio while the browser range-fetches + decodes)."""
+    item_id = _fabricate_direct_playback_item()
+    _open_to_library(page, ui_backend.base_url)
+
+    page.locator(f'.lib-card[data-id="{item_id}"]').click()
+    expect(page.locator("#viewerView")).to_be_visible()
+    try:
+        page.wait_for_function("() => window.rallyClipApp?.directPlayback === true", timeout=15_000)
+    except PlaywrightTimeoutError:
+        pytest.skip("browser cannot decode the VP9 source; direct playback unavailable")
+
+    initial_video_id = page.evaluate("() => window.rallyClipApp.matchVideo.id")
+    # Muted so headless Chromium's autoplay policy cannot block play(); the
+    # swap copies muted/volume to the standby element.
+    page.evaluate(
+        """() => {
+            const app = window.rallyClipApp;
+            app.matchVideo.muted = true;
+            app.matchVideoBuffer.muted = true;
+            app.seekViewerToSourceTime(1.4, true);
+        }"""
+    )
+    # Playback must roll out of point 1 (1-2s) and land in point 2 (4-5s) on
+    # its own — the watcher prepares the standby and swaps at the boundary.
+    page.wait_for_function(
+        "() => window.rallyClipApp.getViewerSourceTime() >= 3.9",
+        timeout=20_000,
+    )
+    after = page.evaluate(
+        """() => {
+            const app = window.rallyClipApp;
+            return {
+                videoId: app.matchVideo.id,
+                time: app.getViewerSourceTime(),
+                paused: app.matchVideo.paused,
+                direct: app.directPlayback,
+                windowStart: Number(app.matchVideo.dataset.windowStart),
+            };
+        }"""
+    )
+    assert after["videoId"] != initial_video_id, "boundary should swap video elements, not seek in place"
+    assert after["direct"] is True
+    assert after["paused"] is False
+    assert after["windowStart"] == 0
+    assert 3.9 <= after["time"] <= 5.6
 
 
 def test_ui_segment_edit_mode_trims_adds_deletes_and_resets(page: Page, ui_backend: BackendClient):

--- a/tests/test_gui_playwright.py
+++ b/tests/test_gui_playwright.py
@@ -737,13 +737,13 @@ def test_ui_direct_playback_swaps_to_preseeked_standby_between_points(page: Page
             const app = window.rallyClipApp;
             app.matchVideo.muted = true;
             app.matchVideoBuffer.muted = true;
-            app.seekViewerToSourceTime(1.4, true);
+            app.seekViewerToSourceTime(1.0, true);
         }"""
     )
     # Playback must roll out of point 1 (1-2s) and land in point 2 (4-5s) on
     # its own — the watcher prepares the standby and swaps at the boundary.
     page.wait_for_function(
-        "() => window.rallyClipApp.getViewerSourceTime() >= 3.9",
+        "() => window.rallyClipApp.getViewerSourceTime() >= 4.0",
         timeout=20_000,
     )
     after = page.evaluate(
@@ -762,7 +762,7 @@ def test_ui_direct_playback_swaps_to_preseeked_standby_between_points(page: Page
     assert after["direct"] is True
     assert after["paused"] is False
     assert after["windowStart"] == 0
-    assert 3.9 <= after["time"] <= 5.1
+    assert 4.0 <= after["time"] <= 5.1
 
 
 def test_ui_segment_edit_mode_trims_adds_deletes_and_resets(page: Page, ui_backend: BackendClient):


### PR DESCRIPTION
## Problem
Watching a match in the viewer, there's an audible pause between plays: audio stops, then restarts. Two causes in the direct-playback path:
1. End-of-point detection relied on `timeupdate` (~250ms granularity in WebKit), so the jump started late.
2. The jump itself was a cold `currentTime` seek on the playing element — WKWebView stalls audio/video while it range-fetches and decodes at the new position.

## Fix
- **rAF watcher** (`startDirectSegmentWatcher`): while direct playback is rolling, poll source time at frame granularity; parks on pause, restarted by the play handler.
- **Pre-seeked standby swap** (`prepareDirectStandby` / `tryDirectStandbySwap`): ~5s before a point ends, the idle second `<video>` element (already in the DOM from the window pipeline) is seeked to the next point's start. At the boundary the elements swap — play the standby, pause the old one, flip `is-active` — so no seek happens at transition time. The old element keeps its src and becomes the standby for the following transition.
- Cold seek remains the fallback whenever the standby isn't ready (slow disk, edited segments invalidating the pre-seek, play() rejection).
- Self-healing: the swap verifies the prepared target still matches `pointIntervals` (segment edits can rewrite it) and that the standby actually sits within 0.75s of the target.
- Invalidation on item switch, viewer exit, and mid-stream fallback to preview windows. Edit mode is untouched (plays straight through, watcher skips).

MSE/WebM preview-window paths are unchanged; all new code is gated on `directPlayback`.

## Tests
- New e2e: `test_ui_direct_playback_swaps_to_preseeked_standby_between_points` — uses a **VP9-in-MP4** fixture because Chromium can't decode the mpeg4 smoke clip, so the direct path never engaged under Playwright before. Asserts playback rolls from point 1 into point 2 on its own and that the video *element* changed (swap, not seek). Skips cleanly if the browser can't decode VP9.
- `make_clip` gains a `codec` param (default unchanged).
- Full playwright module 8/8, smoke + API contracts 39/39 locally.

Feature: `continuous-playback-no-gaps`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing viewer playback with new timing, dual-video, and swap logic; mitigated by directPlayback gating, cold-seek fallbacks, and a Playwright e2e on the transition path.
> 
> **Overview**
> Fixes **audible gaps** when the viewer jumps between points during **direct source playback** (`/api/library/<id>/source`).
> 
> While a point is playing, a **`requestAnimationFrame` segment watcher** detects the end sooner than `timeupdate` (~250ms late). Before the boundary, the idle second `<video>` is **pre-seeked** to the next point; optionally **warmed** (muted, hidden `play()` through the gap tail) so audio does not wait on WKWebView startup. At the end, **`advanceAfterActivePlaybackSegment`** prefers a **dual-element swap** (`tryDirectStandbySwap`) over a cold `currentTime` seek; standby prep is invalidated on pause, manual seek, edit mode, item switch, and preview-window fallback.
> 
> **Timeline UI:** point markers on the seek bar are **shown** again (neon bars over a white progress track; hidden in edit mode).
> 
> **Tests:** `make_clip` accepts a **`codec`** arg; Playwright adds a **VP9-in-MP4** library fixture and **`test_ui_direct_playback_swaps_to_preseeked_standby_between_points`** (asserts element swap, not in-place seek). Docs (`DECISIONS`, `PROGRESS`, `REPO_MAP`) record shipped features and this continuous-playback work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b65cd58a09fe4c8b8179de14c4f7bdba6b237d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->