### PR TITLE
Release v0.2.0: version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rallyclip"
-version = "0.1.0"
+version = "0.2.0"
 description = "Local tennis match segmentation — CLI and desktop app"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
One-line bump so the v0.2.0 build self-reports 0.2.0 (the in-app update checker reads package metadata; without this the shipped app would nag itself to update).

Release contents since v0.1.x: app-data storage migration (#28), viewer direct playback (#29), CoreML spike docs (#30), segment edit mode (#31), gapless point-to-point playback + timeline point bars (#33).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or dependency changes beyond the version string.
> 
> **Overview**
> Bumps **`rallyclip`** project version in `pyproject.toml` from **0.1.0** to **0.2.0** so installed/shipped builds report the correct release via package metadata (`importlib.metadata.version` / `current_app_version()`).
> 
> This aligns the self-reported version with the v0.2.0 release tag and avoids the in-app GitHub update check treating the shipped app as outdated when it already matches the latest release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6ef1081eaeba5ca5f85a6c44f6b4832436e5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->