### PR TITLE
Release fixes: white thumb on top, no pause flash, un-break release e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,13 +125,15 @@ jobs:
           BIN="$(pwd)/dist/RallyClip/RallyClip"
           if [ "${{ runner.os }}" = "Windows" ]; then BIN="$BIN.exe"; fi
 
-          # Full frozen pipeline: PyAV decode -> court-mask fallback -> pose
-          # (downloads nano YOLO weights into $RUNNER_TEMP/models) -> features
-          # -> ONNX inference -> CSV. Zero detected segments is expected on a
+          # Full frozen pipeline: PyAV decode -> court detection -> pose ->
+          # features -> ONNX inference -> CSV, all on the bundled ONNX
+          # weights from the model manifest. No --yolo-size: that flag maps
+          # to a .pt checkpoint, which routes to ultralytics — excluded from
+          # the torch-free bundle. Zero detected segments is expected on a
           # synthetic clip; the assertion is exit 0 + a header CSV.
           python scripts/make_smoke_clip.py "$RUNNER_TEMP/smoke.mp4"
           cd "$RUNNER_TEMP"
-          "$BIN" --cli --video ./smoke.mp4 --yolo-size nano \
+          "$BIN" --cli --video ./smoke.mp4 \
             --write-csv --csv-output-dir ./csv_out --no-segment-video
           test -f csv_out/smoke_segments.csv
           head -1 csv_out/smoke_segments.csv | grep -q "start_time,end_time"

--- a/src/gui/frontend/index.html
+++ b/src/gui/frontend/index.html
@@ -57,6 +57,7 @@
                         <div class="viewer-timeline" id="viewerTimeline" hidden>
                             <div class="viewer-seek-wrap">
                                 <div class="viewer-buffer-track" id="viewerBufferTrack" aria-hidden="true"></div>
+                                <div class="viewer-track-underlay" aria-hidden="true"></div>
                                 <div class="viewer-point-track" id="viewerPointTrack" aria-hidden="true"></div>
                                 <input type="range" id="viewerSeek" min="0" max="0" step="0.1" value="0" aria-label="Match timeline">
                                 <div class="viewer-edit-track" id="viewerEditTrack" hidden></div>

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -1057,14 +1057,17 @@ class RallyClipApp {
         const previous = this.matchVideo;
         this.directStandby = null;
         standby.volume = previous.volume;
-        previous.pause();
         standby.muted = previous.muted;
+        // Reassign before pausing: pause events dispatch synchronously, and
+        // the pause handler ignores non-current videos — so the outgoing
+        // element's pause can't flash a paused state in the controls mid-swap.
+        this.matchVideo = standby;
+        this.matchVideoBuffer = previous;
+        previous.pause();
         // On a warm (already-rolling) standby play() resolves immediately;
         // on a cold one it starts playback — either way the catch below
         // falls back to a seek if the engine refuses.
         const playPromise = standby.play();
-        this.matchVideo = standby;
-        this.matchVideoBuffer = previous;
         standby.classList.add("is-active");
         standby.classList.remove("is-outgoing");
         standby.tabIndex = 0;
@@ -2534,7 +2537,10 @@ class RallyClipApp {
         this.viewerCurrentTime.textContent = this.formatClock(safeTime);
         const max = Number(this.viewerSeek.max) || 0;
         const progress = max > 0 ? Math.max(0, Math.min(100, (safeTime / max) * 100)) : 0;
-        this.viewerSeek.style.setProperty("--viewer-progress", `${progress}%`);
+        // Set on the wrap: the white track/progress renders in the underlay
+        // div (the input's own track is transparent so its thumb can sit
+        // above the point bars).
+        this.viewerSeekWrap.style.setProperty("--viewer-progress", `${progress}%`);
         if (!this.viewerSeekDragging) {
             this.viewerSeek.value = String(Math.min(safeTime, max || safeTime));
         }

--- a/src/gui/frontend/styles.css
+++ b/src/gui/frontend/styles.css
@@ -634,8 +634,27 @@ select {
     display: none;
 }
 
-/* Sits above the range input (z2) so the neon bars read on top of the white
-   track; pointer-events none keeps the input scrubbable through it. */
+/* Timeline stack: white track + progress underlay (z1) -> neon point bars
+   (z3) -> range input with transparent track and white thumb (z4), so the
+   playhead ball rides above everything while the bars stay above the track. */
+.viewer-track-underlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 0.32rem;
+    border-radius: 999px;
+    background: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.95) 0 var(--viewer-progress, 0%),
+        rgba(255, 255, 255, 0.3) var(--viewer-progress, 0%) 100%
+    );
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
+    pointer-events: none;
+    z-index: 1;
+}
+
 .viewer-point-track {
     position: absolute;
     inset: 0;
@@ -664,7 +683,7 @@ select {
     appearance: none;
     -webkit-appearance: none;
     position: relative;
-    z-index: 2;
+    z-index: 4;
     width: 100%;
     height: 0.75rem;
     margin: 0;
@@ -673,15 +692,12 @@ select {
     cursor: pointer;
 }
 
+/* Track visuals live in .viewer-track-underlay; the input's own track stays
+   transparent so only the thumb renders at this (topmost) layer. */
 .viewer-seek-wrap input[type="range"]::-webkit-slider-runnable-track {
     height: 0.32rem;
     border-radius: 999px;
-    background: linear-gradient(
-        to right,
-        rgba(255, 255, 255, 0.95) 0 var(--viewer-progress, 0%),
-        rgba(255, 255, 255, 0.3) var(--viewer-progress, 0%) 100%
-    );
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
+    background: transparent;
 }
 
 .viewer-seek-wrap input[type="range"]::-webkit-slider-thumb {
@@ -691,21 +707,20 @@ select {
     margin-top: -0.365rem;
     border: 0;
     border-radius: 999px;
-    background: var(--tennis);
-    box-shadow: 0 0 0 4px rgba(204, 255, 0, 0.16), 0 2px 12px rgba(0, 0, 0, 0.72);
+    background: #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.8), 0 2px 12px rgba(0, 0, 0, 0.72);
 }
 
 .viewer-seek-wrap input[type="range"]::-moz-range-track {
     height: 0.32rem;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.3);
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
+    background: transparent;
 }
 
 .viewer-seek-wrap input[type="range"]::-moz-range-progress {
     height: 0.32rem;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.95);
+    background: transparent;
 }
 
 .viewer-seek-wrap input[type="range"]::-moz-range-thumb {
@@ -713,8 +728,8 @@ select {
     height: 1.05rem;
     border: 0;
     border-radius: 999px;
-    background: var(--tennis);
-    box-shadow: 0 0 0 4px rgba(204, 255, 0, 0.16), 0 2px 12px rgba(0, 0, 0, 0.72);
+    background: #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.8), 0 2px 12px rgba(0, 0, 0, 0.72);
 }
 
 /* ----- Segment edit mode ----- */
@@ -750,7 +765,9 @@ select {
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 3;
+    /* Above the range input (z4): the drag handles must win pointer events
+       over the seek thumb while editing. */
+    z-index: 5;
 }
 
 .viewer-edit-segment {


### PR DESCRIPTION
Three items to green-light the v0.2.x release line:

- **Release build crash (the v0.2.0 tag failure)**: the frozen-bundle e2e passed `--yolo-size nano`, which maps to `yolov8n-pose.pt` and overrides the manifest's ONNX — routing pose extraction to ultralytics, excluded from the torch-free bundle (`ModuleNotFoundError`). The same override degraded court detection to the default mask. Fix: drop the flag; the bundled manifest ONNX drives both. Reproduced the exact step locally against a frozen bundle — passes clean.
- **White playhead above everything**: track visuals move to an underlay div; the input's track goes transparent so its white, black-ringed thumb sits at the top of the timeline stack (underlay z1 → point bars z3 → input z4 → edit track z5, which must keep winning pointer events for drag handles — caught by the edit e2e).
- **No pause-icon flash during boundary swaps**: reassign `matchVideo` before `previous.pause()` so the synchronous pause event is ignored (Greptile finding on #33).

Playwright 8/8 locally after the z-stack fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI comment/workflow and frontend viewer polish with a small playback-order fix; no auth, data, or core inference contract changes beyond aligning e2e with the bundled ONNX path.
> 
> **Overview**
> **Unblocks the torch-free release line** by running the frozen-bundle pipeline e2e without `--yolo-size`, so pose/court use the bundled manifest ONNX instead of a `.pt` path that pulls in excluded **ultralytics**.
> 
> **Viewer timeline** moves the white track and `--viewer-progress` fill into a new **`.viewer-track-underlay`**; the range input track is transparent and the thumb is white with a dark ring, stacked so the playhead sits above neon point bars (edit handles stay on top at z5).
> 
> **Direct playback** swaps the active `<video>` **before** pausing the outgoing element so synchronous `pause` events don’t briefly show paused controls during point-boundary swaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93760d7579f4176cfe60fb5ca82d6c16de55b124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->