### PR TITLE
v0.3.0 polish: CoreML by default on Apple silicon, viewer fade/fullscreen, version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ rallyclip --video "raw_videos/your_match.mp4"
 - `--csv-output-dir PATH` (default: video directory; enable CSV with `--write-csv`)
 - `--write-csv / --no-csv` (default: off)
 - `--yolo-size {nano,small,medium,large}` (default: `small`)
-- `--yolo-device {cpu,cuda,mps,coreml}` (force pose model device; `coreml` runs the bundled static ONNX on the Apple Neural Engine — several times faster pose on Apple silicon, opt-in because `cpu` is the byte-parity reference)
+- `--yolo-device {cpu,cuda,mps,coreml}` (force pose model device; on Apple silicon auto picks `coreml` — the bundled static ONNX on the Apple Neural Engine, several times faster pose — and degrades to `cpu`, the byte-parity reference, whenever CoreML is unusable)
 - Advanced overrides: `--conf`, `--low`, `--high`, `--sigma`, `--seq-len`, `--overlap`, `--min-dur-sec`, `--fps`
 - Artifact overrides: `--artifact-dir`, `--manifest-path`
 - Config file: `--config path/to/config.toml` (defaults to `./config.toml` if present)

--- a/RallyClip.spec
+++ b/RallyClip.spec
@@ -1,6 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 from PyInstaller.utils.hooks import collect_submodules
 from PyInstaller.utils.hooks import collect_all
+from PyInstaller.utils.hooks import copy_metadata
 
 # Torch-free bundle: pose runs on the ONNX inside models/rallyclip_v0.3.1
 # (extraction.yolo_onnx_runner + onnxruntime); no .pt weights, no ultralytics.
@@ -10,6 +11,10 @@ hiddenimports = ['gui.app', 'gui.analysis_worker', 'cli.main', 'runtime.assets',
 hiddenimports += collect_submodules('flask')
 tmp_ret = collect_all('psutil')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+# The in-app update check reads importlib.metadata.version("rallyclip");
+# without the dist-info the frozen app falls back to a hardcoded 0.1.0 and
+# nags about every release — including older ones.
+datas += copy_metadata('rallyclip')
 
 
 a = Analysis(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rallyclip"
-version = "0.2.0"
+version = "0.3.0"
 description = "Local tennis match segmentation — CLI and desktop app"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/extraction/pose_extractor.py
+++ b/src/extraction/pose_extractor.py
@@ -86,7 +86,16 @@ class PoseExtractor:
             from extraction.yolo_onnx_runner import YOLO as OnnxYOLO
 
             model_arg, providers = self._resolve_onnx_session(yolo_arg)
-            self.model = OnnxYOLO(model_arg, providers=providers)
+            try:
+                self.model = OnnxYOLO(model_arg, providers=providers)
+            except Exception as exc:
+                if providers is None:
+                    raise  # the CPU reference path failing is a real error
+                # CoreML session/compile failures (rare: OS/driver quirks)
+                # must degrade to the CPU path, not kill the analysis.
+                logging.warning("POSE: CoreML session failed (%s); using cpu.", exc)
+                self.device = "cpu"
+                self.model = OnnxYOLO(yolo_arg)
         else:
             if self.device == "coreml":
                 # CoreML rides the ONNX runner; ultralytics .pt weights can't use it.

--- a/src/gui/desktop.py
+++ b/src/gui/desktop.py
@@ -68,12 +68,33 @@ def main() -> int:
     # (the QtWebEngine shell needed an explicit downloadRequested handler).
     webview.settings["ALLOW_DOWNLOADS"] = True
 
-    webview.create_window(
+    class _WindowApi:
+        """window.pywebview.api — lets the viewer take the whole screen.
+
+        WKWebView doesn't grant element fullscreen to the page, so the
+        frontend's fullscreen button calls set_fullscreen here (real OS
+        fullscreen on the window) and lays the player over the full window.
+        """
+
+        def __init__(self) -> None:
+            self.window = None
+            self._fullscreen = False
+
+        def set_fullscreen(self, flag) -> bool:
+            flag = bool(flag)
+            if self.window is not None and flag != self._fullscreen:
+                self.window.toggle_fullscreen()
+                self._fullscreen = flag
+            return self._fullscreen
+
+    api = _WindowApi()
+    api.window = webview.create_window(
         "RallyClip",
         f"http://127.0.0.1:{port}/",
         width=1280,
         height=840,
         min_size=(960, 600),
+        js_api=api,
     )
     webview.start()
     return 0

--- a/src/gui/desktop.py
+++ b/src/gui/desktop.py
@@ -80,9 +80,28 @@ def main() -> int:
             self.window = None
             self._fullscreen = False
 
-        def set_fullscreen(self, flag) -> bool:
+        def _sync_backend_flag(self) -> None:
+            # pywebview's cocoa backend keeps its own is_fullscreen and picks
+            # the NSWindow collection behavior from it; an Escape/green-button
+            # exit leaves it stale too, which can turn the next toggle into a
+            # no-op. Repair it to match reality before toggling.
+            try:
+                from webview.platforms.cocoa import BrowserView
+
+                BrowserView.instances[self.window.uid].is_fullscreen = self._fullscreen
+            except Exception:
+                pass
+
+        def set_fullscreen(self, flag, currently_fullscreen=None) -> bool:
+            """Drive OS fullscreen. The frontend passes the window's actual
+            state (window size == screen size), so leaving fullscreen with
+            Escape or the green button can't desync this flag into re-entering
+            fullscreen on the next call."""
             flag = bool(flag)
+            if currently_fullscreen is not None:
+                self._fullscreen = bool(currently_fullscreen)
             if self.window is not None and flag != self._fullscreen:
+                self._sync_backend_flag()
                 self.window.toggle_fullscreen()
                 self._fullscreen = flag
             return self._fullscreen

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -92,6 +92,7 @@ class RallyClipApp {
         this.viewerSeekDragging = false;
         this.activePlaybackSegment = null;
         this.viewerFullscreenFallback = false;
+        this.viewerNativeWindowFullscreen = false;
         this.mseActive = false;
         this.mseDisabled = false;
         this.mseObjectUrl = null;
@@ -300,11 +301,16 @@ class RallyClipApp {
         video.addEventListener("play", () => {
             if (video !== this.matchVideo) return;
             this.updateViewerControls();
+            // The bar is pinned while paused; on resume re-arm its idle fade.
+            // Only if it's already up — a play() from the gapless standby swap
+            // must not flash the bar mid-playback.
+            if (this.viewerVideoWrap?.classList.contains("is-controls-visible")) this.showViewerControls();
             if (this.directPlayback) this.startDirectSegmentWatcher();
         });
         video.addEventListener("pause", () => {
             if (video !== this.matchVideo) return;
             this.updateViewerControls();
+            this.showViewerControls();
             this.cancelDirectStandbyWarmup();
         });
         video.addEventListener("loadedmetadata", () => {
@@ -575,7 +581,7 @@ class RallyClipApp {
             this.renderViewerPointRanges();
             this.viewerSeekDragging = false;
             this.viewerTimeline.hidden = true;
-            this.hideViewerControls();
+            this.hideViewerControls({ force: true });
             this.updateViewerControls();
             this.hidePreviewLoading();
         }
@@ -612,13 +618,18 @@ class RallyClipApp {
         this.viewerControlsHideTimeout = setTimeout(() => this.hideViewerControls(), 2600);
     }
 
-    hideViewerControls() {
+    hideViewerControls(options = {}) {
         if (this.viewerControlsHideTimeout) {
             clearTimeout(this.viewerControlsHideTimeout);
             this.viewerControlsHideTimeout = null;
         }
-        if (this.editMode) return;
         if (!this.viewerVideoWrap) return;
+        if (!options.force) {
+            if (this.editMode) return;
+            // Platform convention: the bar stays up while paused and fades
+            // once playback resumes.
+            if (this.viewerHasVideo() && this.matchVideo.paused) return;
+        }
         this.viewerVideoWrap.classList.remove("is-controls-visible");
         this.viewerVideoWrap.classList.add("is-controls-idle");
     }
@@ -2026,6 +2037,7 @@ class RallyClipApp {
             const fullscreenElement = this.viewerFullscreenElement();
             if (fullscreenElement || this.viewerFullscreenFallback) {
                 this.viewerFullscreenFallback = false;
+                await this.exitNativeWindowFullscreen();
                 if (document.exitFullscreen && fullscreenElement) await document.exitFullscreen();
                 else if (document.webkitExitFullscreen && fullscreenElement) document.webkitExitFullscreen();
                 else if (document.webkitCancelFullScreen && fullscreenElement) document.webkitCancelFullScreen();
@@ -2041,9 +2053,32 @@ class RallyClipApp {
         this.updateViewerFullscreenState();
     }
 
+    async exitNativeWindowFullscreen() {
+        if (!this.viewerNativeWindowFullscreen) return;
+        this.viewerNativeWindowFullscreen = false;
+        try {
+            await window.pywebview?.api?.set_fullscreen(false);
+        } catch (err) {
+            console.warn("Could not exit window fullscreen", err);
+        }
+    }
+
     async requestViewerFullscreen() {
         const target = this.viewerVideoWrap;
         const video = this.matchVideo;
+        // Desktop shell first: WKWebView doesn't grant element fullscreen to
+        // the page, so ask pywebview for real OS fullscreen on the window and
+        // lay the player over it (the fixed-inset fallback layout).
+        if (window.pywebview?.api?.set_fullscreen) {
+            try {
+                await window.pywebview.api.set_fullscreen(true);
+                this.viewerNativeWindowFullscreen = true;
+                this.viewerFullscreenFallback = true;
+                return;
+            } catch (err) {
+                console.warn("pywebview fullscreen failed; trying element fullscreen", err);
+            }
+        }
         try {
             if (target.requestFullscreen) {
                 await target.requestFullscreen();
@@ -2133,6 +2168,7 @@ class RallyClipApp {
         } else if (event.key === "Escape" && this.viewerFullscreenFallback) {
             event.preventDefault();
             this.viewerFullscreenFallback = false;
+            this.exitNativeWindowFullscreen();
             this.updateViewerFullscreenState();
         }
     }
@@ -2872,7 +2908,8 @@ class RallyClipApp {
     }
 
     populateDeviceSelect() {
-        const options = [{ value: "", label: `Auto (${this.autoDevice})` }];
+        const deviceNames = { cuda: "CUDA", mps: "MPS", coreml: "CoreML", cpu: "CPU" };
+        const options = [{ value: "", label: `Auto (${deviceNames[this.autoDevice] || this.autoDevice})` }];
         const deviceLabels = { cuda: "CUDA", mps: "MPS", coreml: "CoreML (fast, Apple)", cpu: "CPU" };
         ["cuda", "mps", "coreml", "cpu"].forEach((device) => {
             const available = this.availableDevices.includes(device);
@@ -2905,7 +2942,9 @@ class RallyClipApp {
         }
         const selected = this.yoloDevice.value;
         if (!selected) {
-            this.deviceNote.textContent = `Auto picks ${this.autoDevice.toUpperCase()} on this machine (CUDA > MPS > CPU).`;
+            const names = { cuda: "CUDA", mps: "MPS", coreml: "CoreML (Apple Neural Engine)", cpu: "CPU" };
+            this.deviceNote.textContent =
+                `Auto picks ${names[this.autoDevice] || this.autoDevice} on this machine (CUDA > CoreML > MPS > CPU).`;
             return;
         }
         if (selected === "coreml") {

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -260,6 +260,7 @@ class RallyClipApp {
         document.addEventListener("keydown", (e) => this.handleViewerKeyboardShortcuts(e), true);
         document.addEventListener("fullscreenchange", () => this.updateViewerFullscreenState());
         document.addEventListener("webkitfullscreenchange", () => this.updateViewerFullscreenState());
+        window.addEventListener("resize", () => this.handleWindowResizeFullscreenSync());
         this.libraryGrid.addEventListener("click", (e) => this.onLibraryClick(e));
 
         this.dropZone.addEventListener("dragover", (e) => {
@@ -2053,11 +2054,34 @@ class RallyClipApp {
         this.updateViewerFullscreenState();
     }
 
+    // Ground truth for the desktop shell: OS fullscreen means the window
+    // occupies the whole screen. Passed to pywebview on every call so an
+    // Escape/green-button exit can't desync its toggle-based state.
+    isWindowFullscreen() {
+        return Boolean(window.screen)
+            && Math.abs(window.innerWidth - window.screen.width) <= 2
+            && Math.abs(window.innerHeight - window.screen.height) <= 2;
+    }
+
+    handleWindowResizeFullscreenSync() {
+        if (!this.viewerNativeWindowFullscreen) return;
+        clearTimeout(this.viewerFullscreenResyncTimer);
+        this.viewerFullscreenResyncTimer = setTimeout(() => {
+            if (this.viewerNativeWindowFullscreen && !this.isWindowFullscreen()) {
+                // The user left OS fullscreen behind our back (Escape or the
+                // green button): drop the fullscreen layout to match.
+                this.viewerNativeWindowFullscreen = false;
+                this.viewerFullscreenFallback = false;
+                this.updateViewerFullscreenState();
+            }
+        }, 250);
+    }
+
     async exitNativeWindowFullscreen() {
         if (!this.viewerNativeWindowFullscreen) return;
         this.viewerNativeWindowFullscreen = false;
         try {
-            await window.pywebview?.api?.set_fullscreen(false);
+            await window.pywebview?.api?.set_fullscreen(false, this.isWindowFullscreen());
         } catch (err) {
             console.warn("Could not exit window fullscreen", err);
         }
@@ -2071,7 +2095,7 @@ class RallyClipApp {
         // lay the player over it (the fixed-inset fallback layout).
         if (window.pywebview?.api?.set_fullscreen) {
             try {
-                await window.pywebview.api.set_fullscreen(true);
+                await window.pywebview.api.set_fullscreen(true, this.isWindowFullscreen());
                 this.viewerNativeWindowFullscreen = true;
                 this.viewerFullscreenFallback = true;
                 return;

--- a/src/gui/frontend/styles.css
+++ b/src/gui/frontend/styles.css
@@ -523,8 +523,10 @@ select {
     transition: opacity 0.22s ease, transform 0.22s ease;
 }
 
-.viewer-video-wrap:hover .viewer-overlay,
-.viewer-video-wrap:focus-within .viewer-overlay,
+/* Visibility is driven purely by the is-controls-visible class (pointer
+   movement / focus / pause re-arm it in JS). A :hover rule here would pin
+   the bar up whenever the cursor rests anywhere over the video and defeat
+   the idle fade-out. */
 .viewer-video-wrap.is-controls-visible .viewer-overlay {
     opacity: 1;
     pointer-events: auto;

--- a/src/runtime/device.py
+++ b/src/runtime/device.py
@@ -45,15 +45,19 @@ def coreml_pose_available() -> bool:
 def detect_available_devices() -> list[DeviceName]:
     """Return acceleration backends available on this machine, in priority order."""
     available: list[DeviceName] = []
-    if _torch_available():
+    has_torch = _torch_available()
+    if has_torch:
         import torch
 
         if torch.cuda.is_available():
             available.append("cuda")
-        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
-            available.append("mps")
     if coreml_pose_available():
         available.append("coreml")
+    if has_torch:
+        import torch
+
+        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+            available.append("mps")
     available.append("cpu")
     return available
 

--- a/src/runtime/device.py
+++ b/src/runtime/device.py
@@ -8,9 +8,11 @@ from typing import Literal, Optional
 
 DeviceName = Literal["cuda", "mps", "coreml", "cpu"]
 
-# Auto-selection order. "coreml" is deliberately absent: the CPU ONNX path is
-# the byte-parity default and CoreML is opt-in only (explicit choice).
-_DEVICE_ORDER: tuple[DeviceName, ...] = ("cuda", "mps", "cpu")
+# Auto-selection order. On Apple silicon CoreML is the auto pick (severalfold
+# faster pose; the shipped app is built for it) and outranks MPS, which is
+# demoted for pose models anyway. The CPU dynamic path remains the byte-parity
+# reference and the automatic fallback whenever CoreML is unusable.
+_DEVICE_ORDER: tuple[DeviceName, ...] = ("cuda", "coreml", "mps", "cpu")
 
 _VALID_DEVICES = frozenset({"cuda", "mps", "coreml", "cpu"})
 
@@ -24,8 +26,14 @@ def _torch_available() -> bool:
 
 
 def coreml_pose_available() -> bool:
-    """CoreML EP usable for pose: Apple silicon + onnxruntime built with the EP."""
+    """CoreML EP usable for pose: Apple silicon (native, not Rosetta) on
+    macOS 12+ (MLProgram floor) with an onnxruntime built with the EP."""
     if sys.platform != "darwin" or platform.machine() != "arm64":
+        return False
+    try:
+        if int(platform.mac_ver()[0].split(".")[0] or 0) < 12:
+            return False
+    except ValueError:
         return False
     try:
         import onnxruntime as ort  # noqa: WPS433 — optional at import time

--- a/tests/test_desktop_dispatch.py
+++ b/tests/test_desktop_dispatch.py
@@ -31,23 +31,24 @@ def test_cli_flag_dispatches_with_flag_stripped(monkeypatch):
     assert calls["argv"] == ["RallyClip", "--video", "match.mp4", "--write-csv"]
 
 
+def _block_webview(monkeypatch):
+    """Make `import webview` fail so the GUI path exits instead of opening a
+    real window (dev venvs used for DMG builds have pywebview installed)."""
+    monkeypatch.setitem(sys.modules, "webview", None)
+
+
 def test_cli_flag_only_recognized_as_argv1(monkeypatch):
     calls = _stub_cli_main(monkeypatch)
-    # Block the Qt path so the test can't start a real QApplication.
-    monkeypatch.setitem(sys.modules, "PySide6", types.ModuleType("PySide6"))
-    for mod in ("PySide6.QtCore", "PySide6.QtGui", "PySide6.QtWidgets", "PySide6.QtWebEngineWidgets"):
-        monkeypatch.delitem(sys.modules, mod, raising=False)
+    _block_webview(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["RallyClip", "--video", "x.mp4", "--cli"])
 
-    assert desktop.main() == 1  # falls through to GUI path, which fails on stub Qt
+    assert desktop.main() == 1  # falls through to GUI path, which fails without pywebview
     assert "argv" not in calls
 
 
 def test_no_args_takes_gui_path(monkeypatch):
     calls = _stub_cli_main(monkeypatch)
-    monkeypatch.setitem(sys.modules, "PySide6", types.ModuleType("PySide6"))
-    for mod in ("PySide6.QtCore", "PySide6.QtGui", "PySide6.QtWidgets", "PySide6.QtWebEngineWidgets"):
-        monkeypatch.delitem(sys.modules, mod, raising=False)
+    _block_webview(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["RallyClip"])
 
     assert desktop.main() == 1

--- a/tests/test_runtime_device.py
+++ b/tests/test_runtime_device.py
@@ -5,6 +5,12 @@ import types
 import pytest
 
 
+def _disable_coreml(monkeypatch):
+    import runtime.device as device_mod
+
+    monkeypatch.setattr(device_mod, "coreml_pose_available", lambda: False)
+
+
 def test_resolve_auto_device_prefers_cuda(monkeypatch):
     torch_mod = types.SimpleNamespace(
         cuda=types.SimpleNamespace(is_available=lambda: True),
@@ -17,6 +23,7 @@ def test_resolve_auto_device_prefers_cuda(monkeypatch):
 
 
 def test_resolve_auto_device_falls_back_to_mps(monkeypatch):
+    _disable_coreml(monkeypatch)
     torch_mod = types.SimpleNamespace(
         cuda=types.SimpleNamespace(is_available=lambda: False),
         backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: True)),
@@ -28,6 +35,7 @@ def test_resolve_auto_device_falls_back_to_mps(monkeypatch):
 
 
 def test_resolve_auto_device_falls_back_to_cpu(monkeypatch):
+    _disable_coreml(monkeypatch)
     torch_mod = types.SimpleNamespace(
         cuda=types.SimpleNamespace(is_available=lambda: False),
         backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: False)),
@@ -50,6 +58,7 @@ def test_resolve_pose_device_honors_explicit_choice(monkeypatch):
 
 
 def test_apply_pose_device_sets_env(monkeypatch):
+    _disable_coreml(monkeypatch)
     torch_mod = types.SimpleNamespace(
         cuda=types.SimpleNamespace(is_available=lambda: False),
         backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: True)),
@@ -79,6 +88,7 @@ def test_apply_pose_device_honors_explicit_mps(monkeypatch):
 
 
 def test_apply_pose_device_gui_mode_ignores_ambient_env(monkeypatch):
+    _disable_coreml(monkeypatch)
     """GUI jobs use set_env=False and must not inherit shell POSE_DEVICE."""
     import os
 
@@ -102,14 +112,22 @@ def test_resolve_pose_device_accepts_coreml():
     assert resolve_pose_device("coreml") == "coreml"
 
 
-def test_auto_device_never_picks_coreml(monkeypatch):
-    """CoreML is opt-in only: even when available, auto stays on the CPU
-    byte-parity default (no torch -> no cuda/mps here)."""
+def test_auto_device_prefers_coreml_when_available(monkeypatch):
+    """The shipped Apple-silicon app should get CoreML without touching
+    settings; CPU is the fallback, not the auto pick (no torch here)."""
     import runtime.device as device_mod
 
     monkeypatch.setattr(device_mod, "_torch_available", lambda: False)
     monkeypatch.setattr(device_mod, "coreml_pose_available", lambda: True)
     assert "coreml" in device_mod.detect_available_devices()
+    assert device_mod.resolve_auto_device() == "coreml"
+
+
+def test_auto_device_without_coreml_stays_cpu(monkeypatch):
+    import runtime.device as device_mod
+
+    monkeypatch.setattr(device_mod, "_torch_available", lambda: False)
+    monkeypatch.setattr(device_mod, "coreml_pose_available", lambda: False)
     assert device_mod.resolve_auto_device() == "cpu"
 
 


### PR DESCRIPTION
## What

Follow-up to #37 (these two commits landed on the feature branch just after it merged; rebased onto main, resolving the version bump over #34's 0.2.0):

- **CoreML is the auto device on Apple silicon** — order is now CUDA > CoreML > MPS > CPU, so the shipped app gets the ~7x pose speedup with zero settings. CPU stays the byte-parity reference and the silent fallback: Rosetta, macOS < 12 (MLProgram floor), missing EP/static export, or a CoreML session failure (session build now degrades instead of raising). Golden CLI parity still pins `--yolo-device cpu`.
- **Viewer controls actually fade out when idle** — a `:hover` CSS rule pinned the bar up whenever the cursor rested on the video. It stays pinned while paused, re-arms on resume, and never flashes at gapless standby swaps.
- **Real OS fullscreen in the desktop shell** — WKWebView never grants element fullscreen to the page; the fullscreen button now drives macOS window fullscreen through a pywebview `js_api` (`set_fullscreen`), with the fixed-inset player layout over the fullscreen window. Escape exits both.
- **Version 0.3.0 + bundled package metadata** — the frozen app used to fall back to a hardcoded 0.1.0 (metadata wasn't in the bundle) and nagged about every release including older ones; the spec now ships `copy_metadata('rallyclip')`. Verified on the built .app: `/api/update/status` reports `current_version 0.3.0, update_available false` against the live v0.2.0 release.
- **Test fix** — `test_desktop_dispatch` GUI-path tests stub `webview` out; with pywebview installed in the venv (a DMG-build requirement) they opened a real window and hung the suite.

## Verification
- Full suite 235 passed / 23 skipped; playwright module 13/13 locally.
- Greptile CLI: clean (5/5 confidence, no review comments) on exactly this diff; its one advisory nit (device-list ordering) is the second commit.
- Built, launch-tested, and manually QA'd via DMG (user-tested: analysis 2.7x faster wall-clock on a real match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af7zsfhk4MjRJRkN9xG6gq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default inference device and CoreML session behavior on Apple silicon (output may differ slightly from CPU); pose path is critical but failures degrade to CPU rather than crashing analysis.
> 
> **Overview**
> **v0.3.0** bumps the package version and ships `rallyclip` dist-info in the PyInstaller bundle so in-app update checks report the real version instead of a hardcoded fallback.
> 
> **Pose on Apple silicon:** Auto device order is now **CUDA → CoreML → MPS → CPU** (CoreML ahead of MPS). `coreml_pose_available()` adds a macOS 12+ gate; ONNX CoreML session creation failures log a warning and **fall back to CPU** instead of aborting analysis. README and the GUI device note reflect the new auto priority.
> 
> **Desktop viewer:** Controls fade when idle (CSS `:hover` no longer pins the bar); they stay visible while paused. Fullscreen uses a pywebview `js_api` (`set_fullscreen`) for real macOS window fullscreen with Escape/green-button desync handling; the frontend syncs via window-size checks.
> 
> **Tests:** Desktop dispatch GUI-path tests stub out `webview` instead of PySide6; device tests expect CoreML as the auto pick when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c437729ef30b0aefa2c479cfb3499446df0243e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->