### PR TITLE
feat: highlight + per-point export (desktop)

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -15,6 +15,7 @@ import time
 import uuid
 import webbrowser
 import csv
+import zipfile
 from datetime import datetime, timedelta
 from importlib import metadata as importlib_metadata
 from fractions import Fraction
@@ -2352,6 +2353,110 @@ def library_video(item_id: str):
     except Exception as exc:
         logging.exception("Could not export library video %s", item_id)
         return jsonify({"error": f"Could not export video: {exc}"}), 500
+
+
+def _library_source_and_intervals(item_id: str) -> tuple[Path, Path, list[tuple[float, float]]]:
+    """Resolve a saved match's source video and its effective point intervals.
+
+    Uses the edited-wins CSV (`resolve_segments`). Raises FileNotFoundError when
+    the source or point intervals are missing — the per-point export flows have
+    no meaning for legacy already-cut items with no CSV.
+    """
+    source_path = _resolve_library_source(item_id)
+    if source_path is None:
+        raise FileNotFoundError("Video not available")
+    csv_path = _resolve_library_segments(item_id)
+    intervals = _sorted_point_intervals(csv_path) if csv_path is not None else []
+    if not intervals:
+        raise FileNotFoundError("No point intervals available")
+    return source_path, csv_path, intervals
+
+
+def _selected_point_indices(raw: Optional[str], count: int) -> list[int]:
+    """Parse a comma-separated `points` query into validated, sorted indices.
+
+    Raises ValueError on malformed input, an empty selection, or out-of-range
+    indices (which the client should never send).
+    """
+    tokens = [tok.strip() for tok in (raw or "").split(",")]
+    try:
+        indices = sorted({int(tok) for tok in tokens if tok != ""})
+    except ValueError as exc:
+        raise ValueError("Invalid points selection") from exc
+    if not indices:
+        raise ValueError("No points selected")
+    if indices[0] < 0 or indices[-1] >= count:
+        raise ValueError("Points selection out of range")
+    return indices
+
+
+@app.route("/api/library/<item_id>/highlight", methods=["GET"])
+def library_highlight(item_id: str):
+    """Concatenate a user-selected subset of points into a single highlight clip.
+
+    `?points=0,2,5` indexes into the effective (edited-wins) sorted intervals.
+    Regenerated per request since the selection varies; serialized with the
+    per-item export lock so concurrent requests don't both re-encode.
+    """
+    try:
+        source_path, _csv_path, intervals = _library_source_and_intervals(item_id)
+        indices = _selected_point_indices(request.args.get("points"), len(intervals))
+        selected = [intervals[i] for i in indices]
+        highlight_path = _library_item_dir(item_id) / "highlight.mp4"
+        with _export_lock(item_id):
+            _load_segment_video()(str(source_path), selected, str(highlight_path))
+        return send_file(str(highlight_path), as_attachment=True, download_name=f"{item_id}_highlight.mp4")
+    except FileNotFoundError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        logging.exception("Could not export highlight for %s", item_id)
+        return jsonify({"error": f"Could not export highlight: {exc}"}), 500
+
+
+@app.route("/api/library/<item_id>/points.zip", methods=["GET"])
+def library_points_zip(item_id: str):
+    """Export each point as its own clip and deliver them as one .zip.
+
+    Files are named `point_01.mp4`, `point_02.mp4`, … in chronological order.
+    The zip is cached and rebuilt only when the source or segments change.
+    """
+    try:
+        source_path, csv_path, intervals = _library_source_and_intervals(item_id)
+        item_dir = _library_item_dir(item_id)
+        points_dir = item_dir / "points"
+        zip_path = item_dir / "points.zip"
+        with _export_lock(item_id):
+            needs_build = not zip_path.exists()
+            if not needs_build:
+                zip_mtime = zip_path.stat().st_mtime
+                needs_build = (
+                    source_path.stat().st_mtime > zip_mtime
+                    or csv_path.stat().st_mtime > zip_mtime
+                )
+            if needs_build:
+                if points_dir.exists():
+                    shutil.rmtree(points_dir)
+                points_dir.mkdir(parents=True, exist_ok=True)
+                segment = _load_segment_video()
+                clip_paths = []
+                for i, interval in enumerate(intervals, start=1):
+                    clip_path = points_dir / f"point_{i:02d}.mp4"
+                    segment(str(source_path), [interval], str(clip_path))
+                    clip_paths.append(clip_path)
+                # ZIP_STORED: mp4 is already compressed, so skip the deflate pass.
+                with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as archive:
+                    for clip_path in clip_paths:
+                        archive.write(clip_path, arcname=clip_path.name)
+        return send_file(str(zip_path), as_attachment=True, download_name=f"{item_id}_points.zip")
+    except FileNotFoundError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        logging.exception("Could not export points zip for %s", item_id)
+        return jsonify({"error": f"Could not export points: {exc}"}), 500
 
 
 @app.route("/api/library/<item_id>/preview", methods=["GET"])

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -2395,14 +2396,16 @@ def library_highlight(item_id: str):
     """Concatenate a user-selected subset of points into a single highlight clip.
 
     `?points=0,2,5` indexes into the effective (edited-wins) sorted intervals.
-    Regenerated per request since the selection varies; serialized with the
-    per-item export lock so concurrent requests don't both re-encode.
+    The output filename encodes the selection so two concurrent requests with
+    different selections never write the same file (which one client could
+    still be streaming); regenerated per request so it reflects current edits.
     """
     try:
         source_path, _csv_path, intervals = _library_source_and_intervals(item_id)
         indices = _selected_point_indices(request.args.get("points"), len(intervals))
         selected = [intervals[i] for i in indices]
-        highlight_path = _library_item_dir(item_id) / "highlight.mp4"
+        token = hashlib.sha1(",".join(map(str, indices)).encode()).hexdigest()[:12]
+        highlight_path = _library_item_dir(item_id) / f"highlight_{token}.mp4"
         with _export_lock(item_id):
             _load_segment_video()(str(source_path), selected, str(highlight_path))
         return send_file(str(highlight_path), as_attachment=True, download_name=f"{item_id}_highlight.mp4")
@@ -2640,10 +2643,17 @@ def _parse_segments_request(payload: Any) -> list[tuple[float, float]]:
 
 
 def _invalidate_library_export(item_id: str) -> None:
-    # export.mp4 was cut from the previous point times; drop it so the next
-    # download re-exports from the effective CSV.
+    # Every cut artifact was derived from the previous point times; drop them
+    # all so the next download re-exports from the effective CSV. points.zip in
+    # particular is mtime-cached, and after a reset the restored segments.csv is
+    # OLDER than the zip, so without this the stale clips would be served.
+    item_dir = _library_item_dir(item_id)
     with _export_lock(item_id):
-        (_library_item_dir(item_id) / "export.mp4").unlink(missing_ok=True)
+        (item_dir / "export.mp4").unlink(missing_ok=True)
+        (item_dir / "points.zip").unlink(missing_ok=True)
+        shutil.rmtree(item_dir / "points", ignore_errors=True)
+        for stale in item_dir.glob("highlight_*.mp4"):
+            stale.unlink(missing_ok=True)
 
 
 @app.route("/api/library/<item_id>/segments", methods=["GET"])

--- a/src/gui/frontend/index.html
+++ b/src/gui/frontend/index.html
@@ -46,7 +46,14 @@
                     <div class="viewer-actions">
                         <button type="button" class="btn btn-secondary" id="viewerEditBtn" hidden>Edit points</button>
                         <button type="button" class="btn btn-secondary" id="viewerCsvBtn" hidden>CSV</button>
-                        <button type="button" class="btn btn-primary" id="viewerExportBtn">Export video</button>
+                        <div class="export-menu-wrap">
+                            <button type="button" class="btn btn-primary" id="viewerExportBtn" aria-haspopup="true" aria-expanded="false">Export ▾</button>
+                            <div class="export-menu" id="viewerExportMenu" role="menu" hidden>
+                                <button type="button" class="export-menu-item" id="exportAllBtn" role="menuitem">All points — one clip</button>
+                                <button type="button" class="export-menu-item" id="exportHighlightBtn" role="menuitem">Selected points — highlight…</button>
+                                <button type="button" class="export-menu-item" id="exportEachBtn" role="menuitem">Each point separately — .zip</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="viewer-video-wrap">
@@ -61,6 +68,7 @@
                                 <div class="viewer-point-track" id="viewerPointTrack" aria-hidden="true"></div>
                                 <input type="range" id="viewerSeek" min="0" max="0" step="0.1" value="0" aria-label="Match timeline">
                                 <div class="viewer-edit-track" id="viewerEditTrack" hidden></div>
+                                <div class="viewer-select-track" id="viewerSelectTrack" hidden></div>
                             </div>
                             <div class="viewer-control-row">
                                 <div class="viewer-left-controls">
@@ -85,6 +93,15 @@
                                     <button type="button" class="btn btn-secondary btn-small" id="editDeletePointBtn" disabled>Delete point</button>
                                     <button type="button" class="btn btn-ghost btn-small" id="editResetBtn" disabled>Reset to original</button>
                                     <button type="button" class="btn btn-primary btn-small" id="editDoneBtn">Done</button>
+                                </div>
+                            </div>
+                            <div class="viewer-edit-bar viewer-select-bar" id="viewerSelectBar" hidden>
+                                <span class="viewer-edit-hint" id="viewerSelectHint">Tap points to add them to the highlight.</span>
+                                <div class="viewer-edit-actions">
+                                    <button type="button" class="btn btn-secondary btn-small" id="selectAllPointsBtn">Select all</button>
+                                    <button type="button" class="btn btn-ghost btn-small" id="selectClearBtn">Clear</button>
+                                    <button type="button" class="btn btn-ghost btn-small" id="selectCancelBtn">Cancel</button>
+                                    <button type="button" class="btn btn-primary btn-small" id="selectExportBtn" disabled>Export highlight</button>
                                 </div>
                             </div>
                         </div>

--- a/src/gui/frontend/script.js
+++ b/src/gui/frontend/script.js
@@ -71,6 +71,9 @@ class RallyClipApp {
         this.editSaveGen = 0;
         this.editSessionDirty = false;
         this.segmentsEdited = false;
+        this.exportMenuOpen = false;
+        this.highlightMode = false;
+        this.highlightSelection = new Set();
         this.minPointSeconds = 0.5;
         this.addPointSeconds = 8;
         // Edit-mode timeline zoom: null = full match; otherwise the visible
@@ -165,6 +168,17 @@ class RallyClipApp {
         this.viewerCurrentTime = document.getElementById("viewerCurrentTime");
         this.viewerDuration = document.getElementById("viewerDuration");
         this.viewerExportBtn = document.getElementById("viewerExportBtn");
+        this.viewerExportMenu = document.getElementById("viewerExportMenu");
+        this.exportAllBtn = document.getElementById("exportAllBtn");
+        this.exportHighlightBtn = document.getElementById("exportHighlightBtn");
+        this.exportEachBtn = document.getElementById("exportEachBtn");
+        this.viewerSelectTrack = document.getElementById("viewerSelectTrack");
+        this.viewerSelectBar = document.getElementById("viewerSelectBar");
+        this.viewerSelectHint = document.getElementById("viewerSelectHint");
+        this.selectAllPointsBtn = document.getElementById("selectAllPointsBtn");
+        this.selectClearBtn = document.getElementById("selectClearBtn");
+        this.selectCancelBtn = document.getElementById("selectCancelBtn");
+        this.selectExportBtn = document.getElementById("selectExportBtn");
         this.viewerCsvBtn = document.getElementById("viewerCsvBtn");
         this.viewerEditBtn = document.getElementById("viewerEditBtn");
         this.viewerEditTrack = document.getElementById("viewerEditTrack");
@@ -225,8 +239,31 @@ class RallyClipApp {
         this.updateBtn.addEventListener("click", () => this.openUpdatePage());
         this.backToLibrary.addEventListener("click", () => this.showLibrary());
         this.backFromViewer.addEventListener("click", () => this.showLibrary());
-        this.viewerExportBtn.addEventListener("click", () => {
+        this.viewerExportBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            this.toggleExportMenu();
+        });
+        this.exportAllBtn.addEventListener("click", () => {
+            this.closeExportMenu();
             if (this.viewingItemId) this.triggerDownload(`/api/library/${this.viewingItemId}/video`);
+        });
+        this.exportEachBtn.addEventListener("click", () => {
+            this.closeExportMenu();
+            if (this.viewingItemId) this.triggerDownload(`/api/library/${this.viewingItemId}/points.zip`);
+        });
+        this.exportHighlightBtn.addEventListener("click", () => {
+            this.closeExportMenu();
+            this.enterHighlightMode();
+        });
+        this.selectAllPointsBtn.addEventListener("click", () => this.selectAllPoints());
+        this.selectClearBtn.addEventListener("click", () => this.clearHighlightSelection());
+        this.selectCancelBtn.addEventListener("click", () => this.exitHighlightMode());
+        this.selectExportBtn.addEventListener("click", () => this.exportHighlight());
+        // Close the export menu on any outside click.
+        document.addEventListener("click", (e) => {
+            if (!this.exportMenuOpen) return;
+            if (this.viewerExportMenu.contains(e.target) || this.viewerExportBtn.contains(e.target)) return;
+            this.closeExportMenu();
         });
         this.viewerCsvBtn.addEventListener("click", () => {
             if (this.viewingItemId) this.triggerDownload(`/api/library/${this.viewingItemId}/csv`);
@@ -552,6 +589,8 @@ class RallyClipApp {
         this.progressCard.hidden = viewName !== "processing";
         if (viewName !== "viewer" && this.matchVideo) {
             this.exitEditMode({ silent: true });
+            this.closeExportMenu();
+            this.exitHighlightMode();
             this.segmentsEdited = false;
             // Orphan the old item's autosave queue so the next item's saves
             // don't wait behind it (queued ones no-op via the generation bump).
@@ -2306,6 +2345,121 @@ class RallyClipApp {
             this.viewerPointTrack.appendChild(marker);
         });
         if (this.editMode) this.renderEditTrack();
+        if (this.highlightMode) this.renderSelectTrack();
+    }
+
+    // ----- Export menu + highlight selection -------------------------------- //
+    // "Selected points" concatenates a chosen subset into one highlight clip;
+    // "Each point separately" and "All points" are one-click downloads. The
+    // selection is by index into the same (edited-wins) pointIntervals the
+    // timeline draws, so it can't drift from what the user sees.
+
+    toggleExportMenu() {
+        if (this.exportMenuOpen) this.closeExportMenu();
+        else this.openExportMenu();
+    }
+
+    openExportMenu() {
+        if (!this.viewerExportMenu) return;
+        this.exportMenuOpen = true;
+        this.viewerExportMenu.hidden = false;
+        this.viewerExportBtn.setAttribute("aria-expanded", "true");
+    }
+
+    closeExportMenu() {
+        if (!this.viewerExportMenu) return;
+        this.exportMenuOpen = false;
+        this.viewerExportMenu.hidden = true;
+        this.viewerExportBtn.setAttribute("aria-expanded", "false");
+    }
+
+    enterHighlightMode() {
+        if (!this.viewingItemId || !this.pointIntervals.length) {
+            this.showToast("No points to export.", "error");
+            return;
+        }
+        if (this.editMode) this.exitEditMode({ silent: true });
+        this.highlightMode = true;
+        this.highlightSelection = new Set();
+        if (this.viewerHasVideo()) this.matchVideo.pause();
+        if (this.viewerVideoWrap) this.viewerVideoWrap.classList.add("is-selecting");
+        if (this.viewerSelectBar) this.viewerSelectBar.hidden = false;
+        if (this.viewerSelectTrack) this.viewerSelectTrack.hidden = false;
+        this.showViewerControls();
+        this.renderSelectTrack();
+    }
+
+    exitHighlightMode() {
+        this.highlightMode = false;
+        this.highlightSelection = new Set();
+        if (this.viewerVideoWrap) this.viewerVideoWrap.classList.remove("is-selecting");
+        if (this.viewerSelectBar) this.viewerSelectBar.hidden = true;
+        if (this.viewerSelectTrack) {
+            this.viewerSelectTrack.innerHTML = "";
+            this.viewerSelectTrack.hidden = true;
+        }
+    }
+
+    selectAllPoints() {
+        if (!this.highlightMode) return;
+        this.highlightSelection = new Set(this.pointIntervals.map((_, i) => i));
+        this.renderSelectTrack();
+    }
+
+    clearHighlightSelection() {
+        if (!this.highlightMode) return;
+        this.highlightSelection.clear();
+        this.renderSelectTrack();
+    }
+
+    togglePointSelection(index) {
+        if (this.highlightSelection.has(index)) this.highlightSelection.delete(index);
+        else this.highlightSelection.add(index);
+        this.renderSelectTrack();
+    }
+
+    updateSelectUi() {
+        if (!this.viewerSelectBar) return;
+        const count = this.highlightSelection.size;
+        if (this.selectExportBtn) {
+            this.selectExportBtn.disabled = count === 0;
+            this.selectExportBtn.textContent = count ? `Export highlight (${count})` : "Export highlight";
+        }
+        if (this.viewerSelectHint) {
+            this.viewerSelectHint.textContent = count
+                ? `${count} point${count === 1 ? "" : "s"} selected — they’ll play back-to-back.`
+                : "Tap points to add them to the highlight.";
+        }
+    }
+
+    renderSelectTrack() {
+        if (!this.viewerSelectTrack) return;
+        this.viewerSelectTrack.innerHTML = "";
+        this.updateSelectUi();
+        if (!this.highlightMode) return;
+        const win = this.timelineWindow();
+        const span = win.end - win.start;
+        if (span <= 0) return;
+        this.pointIntervals.forEach((seg, index) => {
+            const startPct = Math.max(0, Math.min(100, ((seg.start - win.start) / span) * 100));
+            const endPct = Math.max(startPct, Math.min(100, ((seg.end - win.start) / span) * 100));
+            const el = document.createElement("div");
+            el.className = "viewer-select-segment";
+            el.dataset.index = String(index);
+            el.style.left = `${startPct}%`;
+            el.style.width = `${Math.max(0.4, endPct - startPct)}%`;
+            if (this.highlightSelection.has(index)) el.classList.add("is-selected");
+            el.classList.toggle("is-offscreen", seg.end <= win.start || seg.start >= win.end);
+            el.addEventListener("click", () => this.togglePointSelection(index));
+            this.viewerSelectTrack.appendChild(el);
+        });
+    }
+
+    exportHighlight() {
+        if (!this.viewingItemId || !this.highlightSelection.size) return;
+        const indices = Array.from(this.highlightSelection).sort((a, b) => a - b);
+        this.triggerDownload(`/api/library/${this.viewingItemId}/highlight?points=${indices.join(",")}`);
+        this.exitHighlightMode();
     }
 
     // ----- Segment edit mode ------------------------------------------------ //
@@ -2314,6 +2468,7 @@ class RallyClipApp {
 
     async enterEditMode() {
         if (this.editMode || !this.viewingItemId) return;
+        if (this.highlightMode) this.exitHighlightMode();
         const itemId = this.viewingItemId;
         try {
             const resp = await fetch(`/api/library/${itemId}/segments`);

--- a/src/gui/frontend/styles.css
+++ b/src/gui/frontend/styles.css
@@ -676,9 +676,56 @@ select {
     box-shadow: 0 0 8px rgba(204, 255, 0, 0.35);
 }
 
-/* Edit mode draws its own draggable segments on top; hide the static bars. */
-.viewer-video-wrap.is-editing .viewer-point-track {
+/* Edit / highlight-select mode draw their own segments on top; hide the static bars. */
+.viewer-video-wrap.is-editing .viewer-point-track,
+.viewer-video-wrap.is-selecting .viewer-point-track {
     display: none;
+}
+
+/* ----- Export menu ----- */
+.export-menu-wrap {
+    position: relative;
+}
+
+.export-menu {
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    right: 0;
+    z-index: 20;
+    min-width: 15rem;
+    padding: 0.35rem;
+    border-radius: 0.65rem;
+    background: #14161c;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.export-menu[hidden] {
+    display: none;
+}
+
+.export-menu-item {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.9);
+    text-align: left;
+    padding: 0.55rem 0.7rem;
+    border-radius: 0.45rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.export-menu-item:hover,
+.export-menu-item:focus-visible {
+    background: rgba(204, 255, 0, 0.16);
+    color: #fff;
+    outline: none;
 }
 
 .viewer-seek-wrap input[type="range"] {
@@ -828,10 +875,44 @@ select {
     left: 100%;
 }
 
-.viewer-video-wrap.is-editing .viewer-overlay {
+.viewer-video-wrap.is-editing .viewer-overlay,
+.viewer-video-wrap.is-selecting .viewer-overlay {
     opacity: 1;
     pointer-events: auto;
     transform: translateY(0);
+}
+
+/* ----- Highlight selection mode ----- */
+.viewer-select-track {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    /* Above the range input (z4) so the toggle bars win pointer events. */
+    z-index: 5;
+}
+
+.viewer-select-segment {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 0.95rem;
+    border-radius: 0.35rem;
+    background: rgba(255, 255, 255, 0.14);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    pointer-events: auto;
+    cursor: pointer;
+    touch-action: none;
+}
+
+.viewer-select-segment.is-offscreen {
+    display: none;
+}
+
+.viewer-select-segment.is-selected {
+    background: rgba(204, 255, 0, 0.62);
+    border-color: var(--tennis);
+    height: 1.25rem;
+    box-shadow: 0 0 10px rgba(204, 255, 0, 0.4);
 }
 
 .empty-title {

--- a/tests/test_api_point_export.py
+++ b/tests/test_api_point_export.py
@@ -137,3 +137,25 @@ def test_points_zip_is_cached_until_segments_change(client, match):
 def test_points_zip_unknown_item_404(client, match):
     resp = client.get("/api/library/nope/points.zip")
     assert resp.status_code == 404
+
+
+# ----- cache invalidation on edit/reset ----- #
+
+
+def test_invalidate_drops_all_cut_artifacts(client, match):
+    """Editing/resetting segments must drop the zip + highlight caches too, not
+    just export.mp4 — otherwise the mtime-cached zip serves pre-edit clips."""
+    client.get("/api/library/item-a/points.zip")
+    client.get("/api/library/item-a/highlight?points=0,2")
+    item_dir = match["dir"]
+    (item_dir / "export.mp4").write_bytes(b"x")
+    assert (item_dir / "points.zip").exists()
+    assert (item_dir / "points").exists()
+    assert list(item_dir.glob("highlight_*.mp4"))
+
+    gui_app._invalidate_library_export("item-a")   # what the segments PUT/DELETE handlers call
+
+    assert not (item_dir / "export.mp4").exists()
+    assert not (item_dir / "points.zip").exists()
+    assert not (item_dir / "points").exists()
+    assert not list(item_dir.glob("highlight_*.mp4"))

--- a/tests/test_api_point_export.py
+++ b/tests/test_api_point_export.py
@@ -1,0 +1,139 @@
+"""Contract tests for the per-point export routes.
+
+Covers the two export flows added alongside the single "all points" clip:
+
+  * ``GET /api/library/<id>/highlight?points=…`` — concatenate a selected
+    subset of points into one highlight clip.
+  * ``GET /api/library/<id>/points.zip`` — each point as its own clip, zipped.
+
+``segment_video`` is stubbed so the tests stay fast and assert exactly which
+intervals each route hands the cutter (the numeric selection is the contract).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+os.environ.setdefault("RALLYCLIP_LIBRARY_DIR", "/tmp/rallyclip-test-library")
+
+from gui import app as gui_app  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    return gui_app.app.test_client()
+
+
+@pytest.fixture()
+def match(monkeypatch, tmp_path):
+    """A saved match with three points, and a stubbed cutter recording calls."""
+    monkeypatch.setattr(gui_app, "LIBRARY_DIR", tmp_path)
+    item_dir = tmp_path / "item-a"
+    item_dir.mkdir()
+    (item_dir / "source.mp4").write_bytes(b"\x00")
+    (item_dir / "segments.csv").write_text(
+        "start_time,end_time\n1.0,2.0\n5.0,6.0\n9.0,10.0\n", encoding="utf-8"
+    )
+
+    calls: list[tuple[str, list[tuple[float, float]], str]] = []
+
+    def fake_segment_video(source, intervals, output, *args, **kwargs):
+        calls.append((source, list(intervals), output))
+        # Write a stand-in file so send_file has something to return.
+        Path(output).parent.mkdir(parents=True, exist_ok=True)
+        Path(output).write_bytes(b"CLIP:" + str(list(intervals)).encode())
+
+    monkeypatch.setattr(gui_app, "_load_segment_video", lambda: fake_segment_video)
+    return {"id": "item-a", "dir": item_dir, "calls": calls}
+
+
+# ----- highlight (selected points) ----- #
+
+
+def test_highlight_cuts_only_selected_points(client, match):
+    resp = client.get("/api/library/item-a/highlight?points=0,2")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"].endswith("filename=item-a_highlight.mp4")
+    # One cut call, given exactly the selected intervals in chronological order.
+    assert len(match["calls"]) == 1
+    _source, intervals, _out = match["calls"][0]
+    assert intervals == [(1.0, 2.0), (9.0, 10.0)]
+
+
+def test_highlight_dedupes_and_sorts_indices(client, match):
+    resp = client.get("/api/library/item-a/highlight?points=2,0,2")
+    assert resp.status_code == 200
+    assert match["calls"][0][1] == [(1.0, 2.0), (9.0, 10.0)]
+
+
+def test_highlight_rejects_empty_selection(client, match):
+    resp = client.get("/api/library/item-a/highlight?points=")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "No points selected"}
+    assert match["calls"] == []
+
+
+def test_highlight_rejects_out_of_range(client, match):
+    resp = client.get("/api/library/item-a/highlight?points=0,7")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "Points selection out of range"}
+    assert match["calls"] == []
+
+
+def test_highlight_rejects_non_integer(client, match):
+    resp = client.get("/api/library/item-a/highlight?points=0,abc")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "Invalid points selection"}
+
+
+def test_highlight_unknown_item_404(client, match):
+    resp = client.get("/api/library/nope/highlight?points=0")
+    assert resp.status_code == 404
+
+
+# ----- points.zip (each point individually) ----- #
+
+
+def test_points_zip_has_one_clip_per_point(client, match):
+    resp = client.get("/api/library/item-a/points.zip")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"].endswith("filename=item-a_points.zip")
+
+    # Each point cut on its own, in order.
+    assert [intervals for _s, intervals, _o in match["calls"]] == [
+        [(1.0, 2.0)],
+        [(5.0, 6.0)],
+        [(9.0, 10.0)],
+    ]
+
+    with zipfile.ZipFile(io.BytesIO(resp.data)) as archive:
+        assert archive.namelist() == ["point_01.mp4", "point_02.mp4", "point_03.mp4"]
+
+
+def test_points_zip_is_cached_until_segments_change(client, match):
+    first = client.get("/api/library/item-a/points.zip")
+    assert first.status_code == 200
+    calls_after_first = len(match["calls"])
+
+    # Second request with no changes reuses the built zip: no new cutting.
+    second = client.get("/api/library/item-a/points.zip")
+    assert second.status_code == 200
+    assert len(match["calls"]) == calls_after_first
+
+    # A stale zip (older than the segments/source) is rebuilt on next request.
+    os.utime(match["dir"] / "points.zip", (0, 0))  # make the zip "old"
+    third = client.get("/api/library/item-a/points.zip")
+    assert third.status_code == 200
+    assert len(match["calls"]) > calls_after_first
+
+
+def test_points_zip_unknown_item_404(client, match):
+    resp = client.get("/api/library/nope/points.zip")
+    assert resp.status_code == 404


### PR DESCRIPTION
Two new export options in the match viewer, beside the existing "all points, one clip".

## What

- **Selected points → one highlight clip.** The single *Export video* button becomes an **Export** dropdown (All / Selected… / Each separately). "Selected…" enters a neon **tap-to-select** mode on the timeline; the chosen points are concatenated into one `.mp4` (a highlight reel). Selection is by index into the effective (edited-wins) points, so it can't drift from what the timeline shows.
- **Each point separately → a `.zip`** of `point_01.mp4`, `point_02.mp4`, … (one clip per point, chronological).

## Backend (`src/gui/app.py`)

- `GET /api/library/<id>/highlight?points=0,2,5` — validates/dedupes/range-checks the selection, cuts via `segment_video`. Output filename encodes the selection (`highlight_<sha1(indices)>.mp4`) so concurrent requests with different selections can't clobber a file mid-stream.
- `GET /api/library/<id>/points.zip` — one clip per point, `ZIP_STORED` (mp4 already compressed), mtime-cached.
- `_invalidate_library_export` now drops **all** cut artifacts (`export.mp4`, `points.zip`, `points/`, `highlight_*.mp4`) on edit/reset — not just `export.mp4` — so the mtime-cached zip never serves pre-edit clips.

## Tests

`tests/test_api_point_export.py` — 10 tests: both routes (selection/dedupe/range/404), zip contents + cache, and full cache-invalidation on edit/reset. All green.

## Review

Greptile-reviewed against `main`: **5/5, "safe to merge," no review comments** (a first pass caught a stale-`points.zip`-cache bug + a highlight-filename race, both fixed here).

## Notes

- Based on `c437729` (already on `main`), so the diff is exactly this feature.
- The iOS parity for these two flows ships separately on `feat/ios-app` (PR #39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New ffmpeg-heavy export paths and broader cache invalidation on segment edits; behavior is covered by contract tests and uses existing export locking.
> 
> **Overview**
> Adds **three export paths** from the match viewer: the existing all-points clip, a **custom highlight** built from selected points, and a **per-point `.zip`**.
> 
> The **Export** control becomes a dropdown. **Selected points — highlight…** opens timeline tap-to-select mode (indices match edited-wins intervals); export hits `GET /api/library/<id>/highlight?points=…`. **Each point separately** downloads `GET /api/library/<id>/points.zip` with `point_01.mp4`, etc.
> 
> **Backend** adds shared helpers (`_library_source_and_intervals`, `_selected_point_indices`), highlight output as `highlight_<hash>.mp4` under per-item export lock, and mtime-cached zip rebuild via `segment_video`. **`_invalidate_library_export`** now clears `points.zip`, `points/`, and `highlight_*.mp4` on segment edit/reset so cached zips cannot outlive CSV changes.
> 
> **Tests:** `tests/test_api_point_export.py` covers both routes, zip caching, and invalidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2af6a58372186a39c1cd74674f31c7b96f110d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->