### PR TITLE
docs: remove SwingVision mention from TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -156,7 +156,6 @@ Not included in the first Mac release:
 
 
 - test automating data collection with model self-dataset generation
-- SwingVision data generation: csv vs video matching from cut and whole video for csv generation?
 
 
 - improve postprocessing: train another model with IOU?


### PR DESCRIPTION
## Summary
- Deletes the `SwingVision data generation` bullet from `TODO.md` on `main` tip.
- Tip hygiene only — does not rewrite `55717d7` or other history.

## Test plan
- [ ] Confirm `TODO.md` on the PR branch has no `SwingVision` string
- [ ] Confirm `docs/index.html` landing copy is untouched


Made with [Cursor](https://cursor.com)