### PR TITLE
Add boundary-heatmap runtime pipeline (frame_startend_heatmap)

### DIFF
--- a/src/infer/__init__.py
+++ b/src/infer/__init__.py
@@ -9,7 +9,16 @@ from .inference import (
     run_windowed_inference_average_stream,
     run_windowed_inference_average_onnx_stream,
     run_windowed_inference_average_torch_stream,
+    run_multitrack_windowed_inference_stream,
+    run_multitrack_windowed_inference_onnx_stream,
+    run_multitrack_windowed_inference_torch_stream,
     write_segments_csv,
+)
+from .heatmap_decode import (
+    HeatmapDecodeConfig,
+    decode_heatmap_segments,
+    decode_hybrid,
+    decode_peakpair,
 )
 
 __all__ = [
@@ -24,7 +33,14 @@ __all__ = [
     "run_windowed_inference_average_stream",
     "run_windowed_inference_average_onnx_stream",
     "run_windowed_inference_average_torch_stream",
+    "run_multitrack_windowed_inference_stream",
+    "run_multitrack_windowed_inference_onnx_stream",
+    "run_multitrack_windowed_inference_torch_stream",
     "write_segments_csv",
+    "HeatmapDecodeConfig",
+    "decode_heatmap_segments",
+    "decode_hybrid",
+    "decode_peakpair",
 ]
 
 

--- a/src/infer/heatmap_decode.py
+++ b/src/infer/heatmap_decode.py
@@ -1,0 +1,191 @@
+"""Torch-free decode for the boundary-heatmap head.
+
+The runtime counterpart of ``training/eval/heatmap_evaluator``'s decode: given
+per-frame ``(pointness, start_prob, end_prob)`` probability tracks already
+stitched onto a single video timeline plus each frame's timestamp (seconds),
+turn them into point intervals ``(start_s, end_s)`` in **floating-point
+seconds** (sub-frame precision preserved via soft-argmax).
+
+Kept byte-for-byte in step with the training decode so offline six-bin numbers
+transfer to production; the only thing dropped here is the torch/h5py model-eval
+scaffolding, which the runtime does not need. No torch import — this module runs
+in the shipped ONNX-only runtime.
+
+Two decode modes:
+  - "hybrid" (default): detect points as runs of above-threshold pointness (the
+    same robust detector the classic head uses -- one segment per detected
+    point, no chance of losing a point to a missed boundary peak), then *refine*
+    each run's start/end to sub-frame precision via soft-argmax of the
+    start/end heatmap near the run edge. Targets boundary error without touching
+    recall.
+  - "peakpair": pure BSN-style -- peak-pick startness and endness (with NMS),
+    soft-argmax refine, greedy-pair start->next-end under a duration gate,
+    optional pointness gate. More fragile; kept selectable for parity.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+Interval = Tuple[float, float]
+
+
+@dataclass
+class HeatmapDecodeConfig:
+    mode: str = "hybrid"  # hybrid | peakpair
+    threshold: float = 0.5  # pointness threshold (hybrid run detection)
+    peak_threshold: float = 0.3  # start/end heatmap peak threshold (peakpair mode)
+    sigma_frames: float = 2.5  # sets default refine / NMS windows
+    refine_window_frames: Optional[int] = None  # default ceil(2*sigma)
+    nms_frames: Optional[int] = None  # default ceil(sigma); min peak separation
+    min_duration_sec: float = 0.3
+    max_duration_sec: float = 60.0
+    pointness_gate: Optional[float] = None  # peakpair mode; None disables
+
+    def _refine_window(self) -> int:
+        return int(self.refine_window_frames if self.refine_window_frames is not None
+                   else max(1, math.ceil(2.0 * self.sigma_frames)))
+
+    def _nms(self) -> int:
+        return int(self.nms_frames if self.nms_frames is not None
+                   else max(1, math.ceil(self.sigma_frames)))
+
+
+def _merge_intervals(segments: List[Interval]) -> List[Interval]:
+    segments = sorted(s for s in segments if s[1] > s[0])
+    merged: List[Interval] = []
+    for seg in segments:
+        if merged and seg[0] <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], seg[1]))
+        else:
+            merged.append(seg)
+    return merged
+
+
+def _soft_argmax_time(
+    prob: np.ndarray, timestamps: np.ndarray, center: int, window: int
+) -> float:
+    """Probability-weighted mean of frame times in [center-window, center+window].
+    Falls back to the plain window-centre time if the local heatmap mass vanishes
+    (so a frame with no boundary signal still yields the run-edge time)."""
+    lo = max(0, center - window)
+    hi = min(len(prob), center + window + 1)
+    w = prob[lo:hi]
+    ts = timestamps[lo:hi]
+    total = float(w.sum())
+    if total <= 1e-9:
+        return float(ts.mean())
+    return float(np.average(ts, weights=w))
+
+
+def _pick_peaks(prob: np.ndarray, threshold: float, nms_frames: int) -> List[int]:
+    """Local maxima (>= both neighbours) above threshold, then NMS: keep peaks in
+    descending prob, drop any within nms_frames of an already-kept, stronger peak."""
+    n = len(prob)
+    cand: List[int] = []
+    for i in range(n):
+        if prob[i] < threshold:
+            continue
+        left_ok = i == 0 or prob[i] >= prob[i - 1]
+        right_ok = i == n - 1 or prob[i] >= prob[i + 1]
+        if left_ok and right_ok:
+            cand.append(i)
+    cand.sort(key=lambda i: float(prob[i]), reverse=True)
+    kept: List[int] = []
+    for i in cand:
+        if all(abs(i - k) > nms_frames for k in kept):
+            kept.append(i)
+    kept.sort()
+    return kept
+
+
+def _runs_above(prob: np.ndarray, threshold: float) -> List[Tuple[int, int]]:
+    """(first_idx, last_idx) of each contiguous run of prob >= threshold."""
+    runs: List[Tuple[int, int]] = []
+    n = len(prob)
+    i = 0
+    while i < n:
+        if prob[i] < threshold:
+            i += 1
+            continue
+        j = i
+        while j + 1 < n and prob[j + 1] >= threshold:
+            j += 1
+        runs.append((i, j))
+        i = j + 1
+    return runs
+
+
+def decode_hybrid(
+    pointness: np.ndarray,
+    start_prob: np.ndarray,
+    end_prob: np.ndarray,
+    timestamps: np.ndarray,
+    cfg: HeatmapDecodeConfig,
+) -> List[Interval]:
+    window = cfg._refine_window()
+    segments: List[Interval] = []
+    for i, j in _runs_above(pointness, cfg.threshold):
+        s = _soft_argmax_time(start_prob, timestamps, i, window)
+        e = _soft_argmax_time(end_prob, timestamps, j, window)
+        # Refinement must not invert or escape the detected run's rough span.
+        if e <= s:
+            s, e = float(timestamps[i]), float(timestamps[j])
+        if e > s:
+            segments.append((s, e))
+    return _merge_intervals(segments)
+
+
+def decode_peakpair(
+    pointness: np.ndarray,
+    start_prob: np.ndarray,
+    end_prob: np.ndarray,
+    timestamps: np.ndarray,
+    cfg: HeatmapDecodeConfig,
+) -> List[Interval]:
+    window = cfg._refine_window()
+    nms = cfg._nms()
+    start_peaks = _pick_peaks(start_prob, cfg.peak_threshold, nms)
+    end_peaks = _pick_peaks(end_prob, cfg.peak_threshold, nms)
+    start_times = sorted(_soft_argmax_time(start_prob, timestamps, p, window) for p in start_peaks)
+    end_times = sorted(_soft_argmax_time(end_prob, timestamps, p, window) for p in end_peaks)
+
+    segments: List[Interval] = []
+    ei = 0
+    used = [False] * len(end_times)
+    for st in start_times:
+        k = ei
+        while k < len(end_times) and (used[k] or end_times[k] < st + cfg.min_duration_sec):
+            k += 1
+        if k >= len(end_times):
+            continue
+        et = end_times[k]
+        if et - st > cfg.max_duration_sec:
+            continue
+        used[k] = True
+        ei = k + 1
+        if cfg.pointness_gate is not None:
+            lo = np.searchsorted(timestamps, st)
+            hi = np.searchsorted(timestamps, et)
+            span = pointness[lo:hi + 1]
+            if span.size and float(span.mean()) < cfg.pointness_gate:
+                continue
+        segments.append((st, et))
+    return _merge_intervals(segments)
+
+
+def decode_heatmap_segments(
+    pointness: np.ndarray,
+    start_prob: np.ndarray,
+    end_prob: np.ndarray,
+    timestamps: np.ndarray,
+    cfg: HeatmapDecodeConfig,
+) -> List[Interval]:
+    if cfg.mode == "hybrid":
+        return decode_hybrid(pointness, start_prob, end_prob, timestamps, cfg)
+    if cfg.mode == "peakpair":
+        return decode_peakpair(pointness, start_prob, end_prob, timestamps, cfg)
+    raise ValueError(f"Unknown decode mode: {cfg.mode!r} (expected hybrid | peakpair)")

--- a/src/infer/heatmap_decode.py
+++ b/src/infer/heatmap_decode.py
@@ -44,6 +44,15 @@ class HeatmapDecodeConfig:
     min_duration_sec: float = 0.3
     max_duration_sec: float = 60.0
     pointness_gate: Optional[float] = None  # peakpair mode; None disables
+    # --- hybrid-mode false-positive filtering (both default to no-ops, so
+    # existing hybrid results reproduce bit-for-bit) ---
+    # Gaussian-smooth pointness before run detection. The classic decode has
+    # always smoothed (sigma 1.5); hybrid never did, which penalises backbones
+    # with noisier per-frame output (e.g. the TCN vs the naturally-smoothed LSTM).
+    smooth_sigma_frames: Optional[float] = None
+    # Drop decoded segments shorter than this. `min_duration_sec` above is only
+    # consulted by peakpair's pairing loop; hybrid had no duration filter at all.
+    hybrid_min_duration_sec: float = 0.0
 
     def _refine_window(self) -> int:
         return int(self.refine_window_frames if self.refine_window_frames is not None
@@ -52,6 +61,20 @@ class HeatmapDecodeConfig:
     def _nms(self) -> int:
         return int(self.nms_frames if self.nms_frames is not None
                    else max(1, math.ceil(self.sigma_frames)))
+
+
+def _gaussian_smooth(data: np.ndarray, sigma: float) -> np.ndarray:
+    """1D Gaussian filter, numpy-only (this module stays torch/scipy-free).
+    Kept byte-for-byte identical to training's heatmap_evaluator._gaussian_smooth
+    and to infer.inference.gaussian_filter1d so offline numbers transfer."""
+    if sigma <= 0:
+        return data.copy()
+    radius = int(3 * sigma + 0.5)
+    x = np.arange(-radius, radius + 1)
+    kernel = np.exp(-0.5 * (x / sigma) ** 2)
+    kernel = kernel / kernel.sum()
+    padded = np.pad(data, radius, mode="edge")
+    return np.convolve(padded, kernel, mode="valid").astype(data.dtype)
 
 
 def _merge_intervals(segments: List[Interval]) -> List[Interval]:
@@ -127,8 +150,14 @@ def decode_hybrid(
     cfg: HeatmapDecodeConfig,
 ) -> List[Interval]:
     window = cfg._refine_window()
+    # Run detection sees the (optionally) smoothed track; the start/end heatmaps
+    # are left raw so boundary refinement keeps its sub-frame sharpness.
+    detect_track = (
+        pointness if cfg.smooth_sigma_frames is None
+        else _gaussian_smooth(pointness, float(cfg.smooth_sigma_frames))
+    )
     segments: List[Interval] = []
-    for i, j in _runs_above(pointness, cfg.threshold):
+    for i, j in _runs_above(detect_track, cfg.threshold):
         s = _soft_argmax_time(start_prob, timestamps, i, window)
         e = _soft_argmax_time(end_prob, timestamps, j, window)
         # Refinement must not invert or escape the detected run's rough span.
@@ -140,7 +169,12 @@ def decode_hybrid(
         if dur < cfg.min_duration_sec or dur > cfg.max_duration_sec:
             continue
         segments.append((s, e))
-    return _merge_intervals(segments)
+    merged = _merge_intervals(segments)
+    # Duration floor applied AFTER merging, so adjacent fragments that together
+    # form a real point are not discarded individually.
+    if cfg.hybrid_min_duration_sec > 0:
+        merged = [(s, e) for s, e in merged if (e - s) >= cfg.hybrid_min_duration_sec]
+    return merged
 
 
 def decode_peakpair(

--- a/src/infer/heatmap_decode.py
+++ b/src/infer/heatmap_decode.py
@@ -50,8 +50,12 @@ class HeatmapDecodeConfig:
     # always smoothed (sigma 1.5); hybrid never did, which penalises backbones
     # with noisier per-frame output (e.g. the TCN vs the naturally-smoothed LSTM).
     smooth_sigma_frames: Optional[float] = None
-    # Drop decoded segments shorter than this. `min_duration_sec` above is only
-    # consulted by peakpair's pairing loop; hybrid had no duration filter at all.
+    # Drop decoded segments shorter than this, applied AFTER merging.
+    # Distinct from `min_duration_sec` above, which this runtime's hybrid mode
+    # applies per-segment BEFORE merging (and which peakpair uses for pairing).
+    # NOTE: the training decode does NOT apply min/max_duration_sec in hybrid at
+    # all -- a known parity gap between the two implementations, tracked
+    # separately. This knob behaves identically on both sides.
     hybrid_min_duration_sec: float = 0.0
 
     def _refine_window(self) -> int:

--- a/src/infer/heatmap_decode.py
+++ b/src/infer/heatmap_decode.py
@@ -134,8 +134,12 @@ def decode_hybrid(
         # Refinement must not invert or escape the detected run's rough span.
         if e <= s:
             s, e = float(timestamps[i]), float(timestamps[j])
-        if e > s:
-            segments.append((s, e))
+        if e <= s:
+            continue
+        dur = e - s
+        if dur < cfg.min_duration_sec or dur > cfg.max_duration_sec:
+            continue
+        segments.append((s, e))
     return _merge_intervals(segments)
 
 
@@ -165,14 +169,15 @@ def decode_peakpair(
         et = end_times[k]
         if et - st > cfg.max_duration_sec:
             continue
-        used[k] = True
-        ei = k + 1
         if cfg.pointness_gate is not None:
             lo = np.searchsorted(timestamps, st)
             hi = np.searchsorted(timestamps, et)
             span = pointness[lo:hi + 1]
             if span.size and float(span.mean()) < cfg.pointness_gate:
+                # Do not consume the end event: a later start may pair with it.
                 continue
+        used[k] = True
+        ei = k + 1
         segments.append((st, et))
     return _merge_intervals(segments)
 

--- a/src/infer/inference.py
+++ b/src/infer/inference.py
@@ -498,16 +498,20 @@ _HEATMAP_TRACK_ORDER = ("point", "start", "end")
 def _order_heatmap_outputs(output_names: List[str]) -> List[int]:
     """Index order mapping ONNX outputs to [pointness, start, end].
 
-    Prefers name matching ('point'/'start'/'end' substrings) so export-order does
-    not silently swap tracks; falls back to the model's declared output order when
-    names are uninformative.
+    Requires each of 'point'/'start'/'end' to appear in an output name so
+    export-order cannot silently swap tracks. Uninformative names (e.g. out0)
+    fail loudly rather than assuming declaration order.
     """
     lowered = [name.lower() for name in output_names]
     order: List[int] = []
     for key in _HEATMAP_TRACK_ORDER:
         match = next((i for i, nm in enumerate(lowered) if key in nm), None)
         if match is None:
-            return list(range(len(output_names)))  # positional fallback
+            raise ValueError(
+                f"Heatmap ONNX outputs {output_names} missing a name containing "
+                f"{key!r}; expected distinct names for {_HEATMAP_TRACK_ORDER} so "
+                f"tracks cannot be silently mis-ordered."
+            )
         order.append(match)
     if len(set(order)) != len(order):
         # Two keys resolved to the same output (e.g. a name containing both

--- a/src/infer/inference.py
+++ b/src/infer/inference.py
@@ -509,6 +509,15 @@ def _order_heatmap_outputs(output_names: List[str]) -> List[int]:
         if match is None:
             return list(range(len(output_names)))  # positional fallback
         order.append(match)
+    if len(set(order)) != len(order):
+        # Two keys resolved to the same output (e.g. a name containing both
+        # 'start' and 'end'): mapping is ambiguous, and silently feeding one
+        # track to two decode inputs would corrupt boundaries undetectably.
+        raise ValueError(
+            f"Ambiguous heatmap ONNX output names {output_names}: keys "
+            f"{_HEATMAP_TRACK_ORDER} map to indices {order}. Rename the export's "
+            "outputs so each contains exactly one of 'point'/'start'/'end'."
+        )
     return order
 
 

--- a/src/infer/inference.py
+++ b/src/infer/inference.py
@@ -402,6 +402,196 @@ def run_windowed_inference_average_torch_stream(
     )
 
 
+def run_multitrack_windowed_inference_stream(
+    feature_rows,
+    run_window: Callable[[np.ndarray], np.ndarray],
+    sequence_length: int,
+    overlap: int,
+    num_tracks: int,
+    progress_callback: Optional[Callable[[float], None]] = None,
+    total_windows: Optional[int] = None,
+) -> np.ndarray:
+    """Windowed-average inference producing ``num_tracks`` per-frame probability
+    tracks (e.g. pointness / startness / endness) in a single pass.
+
+    Identical windowing and float32 slice-accumulation to
+    :func:`run_windowed_inference_average_stream`, generalised from one track to
+    ``num_tracks``. ``run_window`` maps a ``(sequence_length, F)`` window to a
+    ``(num_tracks, sequence_length)`` probability array. Returns a
+    ``(num_tracks, num_frames)`` float32 array of per-frame averages. Peak feature
+    memory stays O(seq_len); only the (num_tracks, num_frames) accumulator is
+    O(num_frames).
+    """
+    from collections import deque
+
+    L = int(sequence_length)
+    K = int(num_tracks)
+    if L <= 0:
+        raise ValueError("sequence_length must be > 0")
+    if overlap < 0 or overlap >= L:
+        raise ValueError("overlap must be in [0, sequence_length-1]")
+    if K <= 0:
+        raise ValueError("num_tracks must be > 0")
+    step = L - overlap
+
+    ring: deque = deque(maxlen=L)
+    cap = max(L, 1024)
+    summed = np.zeros((K, cap), dtype=np.float32)
+    counts = np.zeros(cap, dtype=np.int32)
+    n = 0
+    next_start = 0
+    fired = 0
+
+    def _grow(size: int) -> None:
+        nonlocal summed, counts, cap
+        if size <= cap:
+            return
+        new_cap = cap
+        while new_cap < size:
+            new_cap *= 2
+        new_s = np.zeros((K, new_cap), dtype=np.float32)
+        new_s[:, : summed.shape[1]] = summed
+        new_c = np.zeros(new_cap, dtype=np.int32)
+        new_c[: counts.size] = counts
+        summed, counts, cap = new_s, new_c, new_cap
+
+    def _fire(start: int) -> None:
+        nonlocal fired
+        window = np.stack(tuple(ring)).astype(np.float32)
+        probs = np.asarray(run_window(window), dtype=np.float32)
+        if probs.shape != (K, L):
+            raise ValueError(
+                f"window output shape mismatch: got {probs.shape}, expected {(K, L)}. "
+                "Check num_tracks / seq_len against model manifest."
+            )
+        summed[:, start:start + L] += probs
+        counts[start:start + L] += 1
+        fired += 1
+        if progress_callback is not None and total_windows:
+            try:
+                progress_callback(fired / float(total_windows))
+            except Exception:
+                pass
+
+    for row in feature_rows:
+        ring.append(np.asarray(row, dtype=np.float32))
+        n += 1
+        _grow(n)
+        if next_start + L <= n:
+            _fire(next_start)
+            next_start += step
+
+    if n < L:
+        raise ValueError("input video too short for the chosen sequence_length")
+    # End-anchored tail window, appended only when it does not coincide with the
+    # last regular start -- matches the single-track path's trailing append.
+    if (next_start - step) + L < n:
+        _fire(n - L)
+
+    denom = np.maximum(counts[:n], 1)
+    return (summed[:, :n] / denom).astype(np.float32)
+
+
+_HEATMAP_TRACK_ORDER = ("point", "start", "end")
+
+
+def _order_heatmap_outputs(output_names: List[str]) -> List[int]:
+    """Index order mapping ONNX outputs to [pointness, start, end].
+
+    Prefers name matching ('point'/'start'/'end' substrings) so export-order does
+    not silently swap tracks; falls back to the model's declared output order when
+    names are uninformative.
+    """
+    lowered = [name.lower() for name in output_names]
+    order: List[int] = []
+    for key in _HEATMAP_TRACK_ORDER:
+        match = next((i for i, nm in enumerate(lowered) if key in nm), None)
+        if match is None:
+            return list(range(len(output_names)))  # positional fallback
+        order.append(match)
+    return order
+
+
+def run_multitrack_windowed_inference_onnx_stream(
+    model_path: str,
+    feature_rows,
+    sequence_length: int,
+    overlap: int,
+    progress_callback: Optional[Callable[[float], None]] = None,
+    total_windows: Optional[int] = None,
+) -> np.ndarray:
+    """Streaming 3-track (pointness/start/end) windowed-average inference for the
+    boundary-heatmap ONNX model. Returns a ``(3, num_frames)`` float32 array of
+    sigmoid-activated probabilities."""
+    if ort is None:
+        raise RuntimeError(
+            "ONNX model requested but onnxruntime is not installed. "
+            "Install dependencies with `pip install .`."
+        )
+    providers = [p for p in ort.get_available_providers() if p in {"CPUExecutionProvider", "CUDAExecutionProvider"}]
+    if not providers:
+        providers = ["CPUExecutionProvider"]
+    session = ort.InferenceSession(model_path, providers=providers)
+    input_name = session.get_inputs()[0].name
+    output_names = [o.name for o in session.get_outputs()]
+    if len(output_names) != 3:
+        raise ValueError(
+            "heatmap ONNX model must expose 3 outputs (pointness/start/end); "
+            f"got {len(output_names)}: {output_names}"
+        )
+    order = _order_heatmap_outputs(output_names)
+    ordered_names = [output_names[i] for i in order]
+
+    def run_window(window: np.ndarray) -> np.ndarray:
+        seq_np = window.astype(np.float32)[None, ...]
+        outs = session.run(ordered_names, {input_name: seq_np})
+        tracks = []
+        for out in outs:
+            arr = np.asarray(out, dtype=np.float32).squeeze()
+            if arr.ndim != 1:
+                arr = arr.reshape(-1)
+            tracks.append(_sigmoid(arr))
+        return np.stack(tracks, axis=0)
+
+    return run_multitrack_windowed_inference_stream(
+        feature_rows, run_window, sequence_length, overlap, num_tracks=3,
+        progress_callback=progress_callback, total_windows=total_windows,
+    )
+
+
+def run_multitrack_windowed_inference_torch_stream(
+    model,
+    device,
+    feature_rows,
+    sequence_length: int,
+    overlap: int,
+    progress_callback: Optional[Callable[[float], None]] = None,
+    total_windows: Optional[int] = None,
+) -> np.ndarray:
+    """Streaming 3-track windowed-average inference for a torch heatmap checkpoint.
+
+    The model's forward must return a 3-tuple of ``[1, seq_len]`` logits
+    (pointness, start, end). Returns a ``(3, num_frames)`` float32 array. Useful
+    for validating the runtime path against a checkpoint before ONNX export."""
+    import torch
+
+    def run_window(window: np.ndarray) -> np.ndarray:
+        seq_tensor = torch.from_numpy(window).unsqueeze(0).to(device)
+        with torch.no_grad():
+            p_logits, s_logits, e_logits = model(seq_tensor)
+        tracks = [
+            torch.sigmoid(p_logits).squeeze().detach().cpu().numpy().astype(np.float32),
+            torch.sigmoid(s_logits).squeeze().detach().cpu().numpy().astype(np.float32),
+            torch.sigmoid(e_logits).squeeze().detach().cpu().numpy().astype(np.float32),
+        ]
+        return np.stack(tracks, axis=0)
+
+    return run_multitrack_windowed_inference_stream(
+        feature_rows, run_window, sequence_length, overlap, num_tracks=3,
+        progress_callback=progress_callback, total_windows=total_windows,
+    )
+
+
 def extract_segments_from_binary(pred: np.ndarray) -> List[Tuple[int, int]]:
     segments: List[Tuple[int, int]] = []
     n = len(pred)

--- a/src/rallyclip_core/contracts.py
+++ b/src/rallyclip_core/contracts.py
@@ -119,3 +119,8 @@ class RuntimeDeps:
     write_segments_csv: Callable[..., Any]
     segment_video: Callable[..., Any]
     apply_pose_device: Optional[Callable[..., Any]] = None
+    # Heatmap pipeline (optional: engine falls back to lazy `infer` imports when
+    # unset, so pre-existing RuntimeDeps constructions keep working unchanged).
+    run_multitrack_windowed_inference_onnx_stream: Optional[Callable[..., Any]] = None
+    decode_heatmap_segments: Optional[Callable[..., Any]] = None
+    heatmap_decode_config_cls: Optional[Any] = None

--- a/src/rallyclip_core/pipelines.py
+++ b/src/rallyclip_core/pipelines.py
@@ -9,6 +9,11 @@ from .contracts import PipelineSpec, UnsupportedPipelineError
 
 FRAME_PROBABILITY_HYSTERESIS = "frame_probability_hysteresis"
 START_END_ATTENTION_VOTING = "start_end_attention_voting"
+FRAME_STARTEND_HEATMAP = "frame_startend_heatmap"
+
+# postprocess.method strings a manifest may use to select the heatmap pipeline
+# without spelling out pipeline.id explicitly.
+_HEATMAP_METHODS = {"heatmap", "heatmap_hybrid", "heatmap_peakpair", "gaussian_heatmap"}
 
 
 def pipeline_id_from_manifest_values(values: Dict[str, Any]) -> str:
@@ -19,6 +24,8 @@ def pipeline_id_from_manifest_values(values: Dict[str, Any]) -> str:
         return str(explicit)
 
     method = str(values.get("postprocess_method") or values.get("postprocess") or "").strip().lower()
+    if method in _HEATMAP_METHODS:
+        return FRAME_STARTEND_HEATMAP
     if method == "hysteresis" or not method:
         return FRAME_PROBABILITY_HYSTERESIS
     return method
@@ -33,12 +40,17 @@ def resolve_pipeline_spec(
     values = manifest_values(model_path, manifest_path)
     default_id = pipeline_id_from_manifest_values(values)
     pipeline_id = override_pipeline_id or default_id
-    if pipeline_id not in {FRAME_PROBABILITY_HYSTERESIS, START_END_ATTENTION_VOTING}:
+    if pipeline_id not in {FRAME_PROBABILITY_HYSTERESIS, START_END_ATTENTION_VOTING, FRAME_STARTEND_HEATMAP}:
         raise UnsupportedPipelineError(f"Unsupported pipeline_id '{pipeline_id}'.")
     if pipeline_id == START_END_ATTENTION_VOTING and default_id != START_END_ATTENTION_VOTING:
         raise UnsupportedPipelineError(
             "Pipeline override 'start_end_attention_voting' is incompatible with this artifact. "
             "Use an artifact whose manifest declares start/end attention outputs."
+        )
+    if pipeline_id == FRAME_STARTEND_HEATMAP and default_id != FRAME_STARTEND_HEATMAP:
+        raise UnsupportedPipelineError(
+            "Pipeline override 'frame_startend_heatmap' is incompatible with this artifact. "
+            "Use an artifact whose manifest declares pointness/start/end heatmap outputs."
         )
     if pipeline_id == FRAME_PROBABILITY_HYSTERESIS:
         return PipelineSpec(
@@ -52,6 +64,16 @@ def resolve_pipeline_spec(
                 "high": values.get("high"),
                 "min_dur_sec": values.get("min_dur_sec"),
             },
+        )
+    if pipeline_id == FRAME_STARTEND_HEATMAP:
+        # Decode knobs come straight from the manifest's postprocess.params; the
+        # runtime HeatmapDecodeConfig fills any it omits with its defaults.
+        return PipelineSpec(
+            pipeline_id=pipeline_id,
+            feature_set=str(values.get("feature_set") or "v1"),
+            model_output="pointness_start_end_heatmap",
+            decode_method="heatmap_hybrid",
+            params=dict(values.get("postprocess_params") or {}),
         )
     return PipelineSpec(
         pipeline_id=pipeline_id,

--- a/src/rallyclip_engine/models.py
+++ b/src/rallyclip_engine/models.py
@@ -7,6 +7,7 @@ from typing import Iterable, List, Optional
 from rallyclip_core.contracts import (
     CancelCheck,
     FrameSegment,
+    Interval,
     PipelineSpec,
     ProgressCallback,
     ProgressEvent,
@@ -15,8 +16,12 @@ from rallyclip_core.contracts import (
     RuntimeDeps,
     UnsupportedPipelineError,
 )
-from rallyclip_core.intervals import frame_segments_to_intervals
-from rallyclip_core.pipelines import FRAME_PROBABILITY_HYSTERESIS, START_END_ATTENTION_VOTING
+from rallyclip_core.intervals import frame_segments_to_intervals, write_point_intervals
+from rallyclip_core.pipelines import (
+    FRAME_PROBABILITY_HYSTERESIS,
+    FRAME_STARTEND_HEATMAP,
+    START_END_ATTENTION_VOTING,
+)
 
 
 def _emit(
@@ -44,6 +49,101 @@ def _estimate_stream_window_count(num_frames: int, sequence_length: int, overlap
     if last_start + sequence_length < num_frames:
         count += 1
     return count
+
+
+def build_feature_stream(
+    request: RunRequest,
+    deps: RuntimeDeps,
+    progress_callback: Optional[ProgressCallback],
+    cancel_check: Optional[CancelCheck],
+):
+    """Shared source-video -> feature-row stream.
+
+    pose (YOLO) -> court mask -> per-frame preprocess -> feature engineering,
+    yielding the v1 362-dim feature rows. Head-agnostic: the frame-probability
+    and boundary-heatmap pipelines consume identical features, differing only in
+    the model head + decode, so this lives at module scope rather than in any one
+    AnalysisModel.
+    """
+    if str(request.feature_set) != "v1":
+        raise UnsupportedPipelineError(
+            f"This model declares feature_set='{request.feature_set}', but only 'v1' "
+            "is implemented in the runtime feature pipeline."
+        )
+
+    yolo_weights = request.yolo_weights
+    if not Path(yolo_weights).is_absolute():
+        # Resolve bare weight names (from the manifest) against the models
+        # directory and the manifest's own directory, so every consumer —
+        # court detection included — gets a concrete file path. Names that
+        # don't resolve stay bare and fall through to ultralytics' own
+        # download/resolution, as before.
+        search_dirs = [Path(request.models_dir or (Path.cwd() / "models"))]
+        if request.manifest_path is not None:
+            search_dirs.append(Path(request.manifest_path).parent)
+        for base in search_dirs:
+            candidate = base / yolo_weights
+            if candidate.exists():
+                yolo_weights = str(candidate)
+                break
+    pose_device = None
+    if request.yolo_device and deps.apply_pose_device is not None:
+        pose_device = deps.apply_pose_device(str(request.yolo_device), model_path=yolo_weights, set_env=False)
+    elif deps.apply_pose_device is not None:
+        pose_device = deps.apply_pose_device(None, model_path=yolo_weights, set_env=False)
+
+    # Court detection runs a handful of frames; CoreML only accelerates the
+    # pose loop, so keep the preprocessor's YOLO on CPU for that device.
+    court_device = "cpu" if pose_device == "coreml" else pose_device
+    pre = deps.DataPreprocessor(
+        screen_width=int(request.screen_width),
+        screen_height=int(request.screen_height),
+        save_court_masks=False,
+        yolo_model_path=yolo_weights,
+        conf=float(request.conf),
+        **({"yolo_device": court_device} if court_device is not None else {}),
+    )
+    _check(cancel_check)
+    _emit(progress_callback, "pose", 1)
+    court_mask, _ = pre.compute_court_mask(str(request.video_path))
+    _emit(progress_callback, "pose", 3)
+
+    _check(cancel_check)
+    extractor_kwargs = {
+        "model_path": yolo_weights,
+        "model_dir": str(request.models_dir or (Path.cwd() / "models")),
+    }
+    if pose_device is not None:
+        extractor_kwargs["device"] = pose_device
+    extractor = deps.PoseExtractor(**extractor_kwargs)
+
+    def pose_progress(frac: float, meta=None) -> None:
+        _check(cancel_check)
+        # meta (frames_seen/frames_total/smoothed fps) feeds client-side
+        # ETA display; forward it rather than dropping it here.
+        _emit(progress_callback, "pose", int(3 + max(0.0, min(1.0, frac)) * 96), metadata=meta or {})
+
+    src_height, src_width, _ = pre._source_frame_shape(str(request.video_path))
+    pose_stream = extractor.iter_pose_frames(
+        video_path=str(request.video_path),
+        confidence_threshold=float(request.conf),
+        start_time_seconds=int(request.start_time),
+        duration_seconds=int(request.duration),
+        target_fps=int(request.fps),
+        imgsz=int(request.imgsz),
+        annotations_csv=None,
+        progress_callback=pose_progress,
+    )
+    preprocessed_stream = pre.iter_preprocess_frames(pose_stream, court_mask, src_width, src_height)
+    fe = deps.FeatureEngineer(
+        screen_width=int(request.screen_width),
+        screen_height=int(request.screen_height),
+        target_fps=float(request.fps),
+    )
+    feature_stream = fe.iter_build_features(preprocessed_stream)
+    _emit(progress_callback, "preprocess", 1)
+    _emit(progress_callback, "feature", 1)
+    return feature_stream
 
 
 class AnalysisModel(ABC):
@@ -113,92 +213,42 @@ class AnalysisModel(ABC):
             diagnostics={"pipeline_id": self.pipeline_id},
         )
 
+    def _write_interval_result(self, intervals_sec: List[Interval]) -> RunResult:
+        """Finalize a model that yields floating-point second intervals directly
+        (e.g. the heatmap head's sub-frame boundaries), preserving precision the
+        frame-segment path would quantize away. RunResult.frame_segments is still
+        populated (rounded) for consumers that count/scan segments."""
+        request = self.request
+        csv_path = None
+        video_path = None
+        base_name = request.output_name or request.video_path.stem
+        if request.write_csv:
+            request.csv_output_dir.mkdir(parents=True, exist_ok=True)
+            csv_path = request.csv_output_dir / f"{base_name}_segments.csv"
+            write_point_intervals(csv_path, intervals_sec)
+        if request.segment_video:
+            request.output_dir.mkdir(parents=True, exist_ok=True)
+            video_path = request.output_dir / f"{base_name}_segmented.mp4"
+            if intervals_sec:
+                self.deps.segment_video(str(request.video_path), intervals_sec, str(video_path))
+        fps = float(request.fps)
+        frame_segments: List[FrameSegment] = [
+            (int(round(s * fps)), int(round(e * fps))) for s, e in intervals_sec
+        ]
+        return RunResult(
+            frame_segments=frame_segments,
+            intervals_sec=intervals_sec,
+            csv_path=csv_path,
+            video_path=video_path,
+            diagnostics={"pipeline_id": self.pipeline_id},
+        )
+
 
 class FrameProbabilityHysteresisModel(AnalysisModel):
     pipeline_id = FRAME_PROBABILITY_HYSTERESIS
 
     def preprocess(self, progress_callback: Optional[ProgressCallback], cancel_check: Optional[CancelCheck]):
-        request = self.request
-        deps = self.deps
-        if str(request.feature_set) != "v1":
-            raise UnsupportedPipelineError(
-                f"This model declares feature_set='{request.feature_set}', but only 'v1' is implemented "
-                "for pipeline 'frame_probability_hysteresis'."
-            )
-
-        yolo_weights = request.yolo_weights
-        if not Path(yolo_weights).is_absolute():
-            # Resolve bare weight names (from the manifest) against the models
-            # directory and the manifest's own directory, so every consumer —
-            # court detection included — gets a concrete file path. Names that
-            # don't resolve stay bare and fall through to ultralytics' own
-            # download/resolution, as before.
-            search_dirs = [Path(request.models_dir or (Path.cwd() / "models"))]
-            if request.manifest_path is not None:
-                search_dirs.append(Path(request.manifest_path).parent)
-            for base in search_dirs:
-                candidate = base / yolo_weights
-                if candidate.exists():
-                    yolo_weights = str(candidate)
-                    break
-        pose_device = None
-        if request.yolo_device and deps.apply_pose_device is not None:
-            pose_device = deps.apply_pose_device(str(request.yolo_device), model_path=yolo_weights, set_env=False)
-        elif deps.apply_pose_device is not None:
-            pose_device = deps.apply_pose_device(None, model_path=yolo_weights, set_env=False)
-
-        # Court detection runs a handful of frames; CoreML only accelerates the
-        # pose loop, so keep the preprocessor's YOLO on CPU for that device.
-        court_device = "cpu" if pose_device == "coreml" else pose_device
-        pre = deps.DataPreprocessor(
-            screen_width=int(request.screen_width),
-            screen_height=int(request.screen_height),
-            save_court_masks=False,
-            yolo_model_path=yolo_weights,
-            conf=float(request.conf),
-            **({"yolo_device": court_device} if court_device is not None else {}),
-        )
-        _check(cancel_check)
-        _emit(progress_callback, "pose", 1)
-        court_mask, _ = pre.compute_court_mask(str(request.video_path))
-        _emit(progress_callback, "pose", 3)
-
-        _check(cancel_check)
-        extractor_kwargs = {
-            "model_path": yolo_weights,
-            "model_dir": str(request.models_dir or (Path.cwd() / "models")),
-        }
-        if pose_device is not None:
-            extractor_kwargs["device"] = pose_device
-        extractor = deps.PoseExtractor(**extractor_kwargs)
-
-        def pose_progress(frac: float, meta=None) -> None:
-            _check(cancel_check)
-            # meta (frames_seen/frames_total/smoothed fps) feeds client-side
-            # ETA display; forward it rather than dropping it here.
-            _emit(progress_callback, "pose", int(3 + max(0.0, min(1.0, frac)) * 96), metadata=meta or {})
-
-        src_height, src_width, _ = pre._source_frame_shape(str(request.video_path))
-        pose_stream = extractor.iter_pose_frames(
-            video_path=str(request.video_path),
-            confidence_threshold=float(request.conf),
-            start_time_seconds=int(request.start_time),
-            duration_seconds=int(request.duration),
-            target_fps=int(request.fps),
-            imgsz=int(request.imgsz),
-            annotations_csv=None,
-            progress_callback=pose_progress,
-        )
-        preprocessed_stream = pre.iter_preprocess_frames(pose_stream, court_mask, src_width, src_height)
-        fe = deps.FeatureEngineer(
-            screen_width=int(request.screen_width),
-            screen_height=int(request.screen_height),
-            target_fps=float(request.fps),
-        )
-        feature_stream = fe.iter_build_features(preprocessed_stream)
-        _emit(progress_callback, "preprocess", 1)
-        _emit(progress_callback, "feature", 1)
-        return feature_stream
+        return build_feature_stream(self.request, self.deps, progress_callback, cancel_check)
 
     def infer(
         self,
@@ -280,6 +330,108 @@ class FrameProbabilityHysteresisModel(AnalysisModel):
         return list(deps.extract_segments_from_binary(binary_pred))
 
 
+class HeatmapHybridModel(AnalysisModel):
+    """Boundary-heatmap head. The model emits three per-frame tracks (pointness,
+    startness, endness); pointness runs detect points (robust recall, same as the
+    classic head) and the start/end heatmaps refine each edge to sub-frame
+    precision via soft-argmax. Produces floating-point second intervals directly.
+    ONNX-only in the shipped runtime."""
+
+    pipeline_id = FRAME_STARTEND_HEATMAP
+
+    def run(
+        self,
+        *,
+        progress_callback: Optional[ProgressCallback] = None,
+        cancel_check: Optional[CancelCheck] = None,
+    ) -> RunResult:
+        features = self.preprocess(progress_callback, cancel_check)
+        tracks = self.infer(features, progress_callback, cancel_check)
+        intervals_sec = self.postprocess(tracks)
+        _emit(progress_callback, "inference", 100, "completed")
+        return self._write_interval_result(intervals_sec)
+
+    def preprocess(self, progress_callback: Optional[ProgressCallback], cancel_check: Optional[CancelCheck]):
+        return build_feature_stream(self.request, self.deps, progress_callback, cancel_check)
+
+    def infer(
+        self,
+        features,
+        progress_callback: Optional[ProgressCallback],
+        cancel_check: Optional[CancelCheck],
+    ):
+        from infer import run_multitrack_windowed_inference_onnx_stream
+
+        request = self.request
+        deps = self.deps
+        if request.model_path.suffix.lower() != ".onnx":
+            raise UnsupportedPipelineError(
+                "The 'frame_startend_heatmap' runtime supports ONNX models only (got "
+                f"'{request.model_path.suffix or request.model_path.name}'); export the heatmap "
+                "checkpoint to model.onnx with 3 outputs (pointness/start/end)."
+            )
+        _emit(progress_callback, "inference", 5)
+        scaler = deps.load_scaler_asset(str(request.scaler_path))
+
+        duration_s = request.estimated_duration_s
+        if duration_s is None:
+            duration_s = float(request.duration) if 0 < int(request.duration) < 999999 else 0.0
+        estimated_feature_rows = max(0, int(round(float(duration_s) * float(request.fps))) - 1)
+        estimated_windows = _estimate_stream_window_count(
+            estimated_feature_rows, int(request.seq_len), int(request.overlap)
+        )
+        feature_rows_seen = 0
+
+        def scaled_feature_rows():
+            nonlocal feature_rows_seen
+            for feature_vector, _target in features:
+                _check(cancel_check)
+                feature_rows_seen += 1
+                if estimated_feature_rows > 0:
+                    frac = min(1.0, feature_rows_seen / float(estimated_feature_rows))
+                    stage_progress = int(1 + frac * 94)
+                    _emit(progress_callback, "preprocess", stage_progress)
+                    _emit(progress_callback, "feature", stage_progress)
+                    if estimated_windows is None:
+                        _emit(progress_callback, "inference", int(5 + frac * 80))
+                row = deps.np.asarray(feature_vector, dtype=deps.np.float32).reshape(1, -1)
+                yield scaler.transform(row)[0].astype(deps.np.float32)
+
+        def infer_progress(frac: float) -> None:
+            _emit(progress_callback, "inference", int(5 + max(0.0, min(1.0, frac)) * 90))
+
+        tracks = run_multitrack_windowed_inference_onnx_stream(
+            str(request.model_path),
+            scaled_feature_rows(),
+            sequence_length=int(request.seq_len),
+            overlap=int(request.overlap),
+            progress_callback=infer_progress,
+            total_windows=estimated_windows,
+        )
+        _emit(progress_callback, "pose", 100, "completed")
+        _emit(progress_callback, "preprocess", 100, "completed")
+        _emit(progress_callback, "feature", 100, "completed")
+        return tracks
+
+    def _decode_config(self):
+        from infer import HeatmapDecodeConfig
+
+        valid = set(HeatmapDecodeConfig.__dataclass_fields__)
+        params = {k: v for k, v in (self.spec.params or {}).items() if k in valid and v is not None}
+        return HeatmapDecodeConfig(**params)
+
+    def postprocess(self, model_output) -> List[Interval]:
+        from infer import decode_heatmap_segments
+
+        np = self.deps.np
+        pointness = np.asarray(model_output[0], dtype=np.float64)
+        start_prob = np.asarray(model_output[1], dtype=np.float64)
+        end_prob = np.asarray(model_output[2], dtype=np.float64)
+        num_frames = int(pointness.shape[0])
+        timestamps = np.arange(num_frames, dtype=np.float64) / float(self.request.fps)
+        return decode_heatmap_segments(pointness, start_prob, end_prob, timestamps, self._decode_config())
+
+
 class StartEndAttentionVotingModel(AnalysisModel):
     pipeline_id = START_END_ATTENTION_VOTING
 
@@ -333,6 +485,8 @@ def decode_start_end_votes(
 def build_analysis_model(request: RunRequest, spec: PipelineSpec, deps: RuntimeDeps) -> AnalysisModel:
     if spec.pipeline_id == FRAME_PROBABILITY_HYSTERESIS:
         return FrameProbabilityHysteresisModel(request, spec, deps)
+    if spec.pipeline_id == FRAME_STARTEND_HEATMAP:
+        return HeatmapHybridModel(request, spec, deps)
     if spec.pipeline_id == START_END_ATTENTION_VOTING:
         return StartEndAttentionVotingModel(request, spec, deps)
     raise UnsupportedPipelineError(f"Unsupported pipeline_id '{spec.pipeline_id}'.")

--- a/src/rallyclip_engine/models.py
+++ b/src/rallyclip_engine/models.py
@@ -360,10 +360,12 @@ class HeatmapHybridModel(AnalysisModel):
         progress_callback: Optional[ProgressCallback],
         cancel_check: Optional[CancelCheck],
     ):
-        from infer import run_multitrack_windowed_inference_onnx_stream
-
         request = self.request
         deps = self.deps
+        run_multitrack = deps.run_multitrack_windowed_inference_onnx_stream
+        if run_multitrack is None:  # pre-existing deps constructions (CLI/GUI/tests)
+            from infer import run_multitrack_windowed_inference_onnx_stream as run_multitrack
+
         if request.model_path.suffix.lower() != ".onnx":
             raise UnsupportedPipelineError(
                 "The 'frame_startend_heatmap' runtime supports ONNX models only (got "
@@ -400,7 +402,7 @@ class HeatmapHybridModel(AnalysisModel):
         def infer_progress(frac: float) -> None:
             _emit(progress_callback, "inference", int(5 + max(0.0, min(1.0, frac)) * 90))
 
-        tracks = run_multitrack_windowed_inference_onnx_stream(
+        tracks = run_multitrack(
             str(request.model_path),
             scaled_feature_rows(),
             sequence_length=int(request.seq_len),
@@ -414,14 +416,18 @@ class HeatmapHybridModel(AnalysisModel):
         return tracks
 
     def _decode_config(self):
-        from infer import HeatmapDecodeConfig
+        config_cls = self.deps.heatmap_decode_config_cls
+        if config_cls is None:  # pre-existing deps constructions (CLI/GUI/tests)
+            from infer import HeatmapDecodeConfig as config_cls
 
-        valid = set(HeatmapDecodeConfig.__dataclass_fields__)
+        valid = set(config_cls.__dataclass_fields__)
         params = {k: v for k, v in (self.spec.params or {}).items() if k in valid and v is not None}
-        return HeatmapDecodeConfig(**params)
+        return config_cls(**params)
 
     def postprocess(self, model_output) -> List[Interval]:
-        from infer import decode_heatmap_segments
+        decode = self.deps.decode_heatmap_segments
+        if decode is None:  # pre-existing deps constructions (CLI/GUI/tests)
+            from infer import decode_heatmap_segments as decode
 
         np = self.deps.np
         pointness = np.asarray(model_output[0], dtype=np.float64)
@@ -429,7 +435,7 @@ class HeatmapHybridModel(AnalysisModel):
         end_prob = np.asarray(model_output[2], dtype=np.float64)
         num_frames = int(pointness.shape[0])
         timestamps = np.arange(num_frames, dtype=np.float64) / float(self.request.fps)
-        return decode_heatmap_segments(pointness, start_prob, end_prob, timestamps, self._decode_config())
+        return decode(pointness, start_prob, end_prob, timestamps, self._decode_config())
 
 
 class StartEndAttentionVotingModel(AnalysisModel):

--- a/src/rallyclip_engine/runtime.py
+++ b/src/rallyclip_engine/runtime.py
@@ -9,11 +9,14 @@ def load_runtime_deps() -> RuntimeDeps:
     from extraction.pose_extractor import PoseExtractor  # noqa: WPS433
     from features.feature_engineer import FeatureEngineer  # noqa: WPS433
     from infer import (  # noqa: WPS433
+        HeatmapDecodeConfig,
+        decode_heatmap_segments,
         extract_segments_from_binary,
         gaussian_filter1d,
         hysteresis_threshold,
         load_model_from_checkpoint,
         load_scaler_asset,
+        run_multitrack_windowed_inference_onnx_stream,
         run_windowed_inference_average_onnx_stream,
         run_windowed_inference_average_torch_stream,
         write_segments_csv,
@@ -37,4 +40,7 @@ def load_runtime_deps() -> RuntimeDeps:
         write_segments_csv=write_segments_csv,
         segment_video=segment_video,
         apply_pose_device=apply_pose_device,
+        run_multitrack_windowed_inference_onnx_stream=run_multitrack_windowed_inference_onnx_stream,
+        decode_heatmap_segments=decode_heatmap_segments,
+        heatmap_decode_config_cls=HeatmapDecodeConfig,
     )

--- a/src/runtime/assets.py
+++ b/src/runtime/assets.py
@@ -121,4 +121,9 @@ def manifest_values(model_path: Path, manifest_path: Optional[Path] = None) -> D
         values["high"] = float(postprocess["high"])
     if postprocess.get("min_dur_sec") is not None:
         values["min_dur_sec"] = float(postprocess["min_dur_sec"])
+    # Full postprocess params passthrough: lets pipelines with their own decode
+    # knobs (e.g. the boundary-heatmap head) read config without every key being
+    # hardcoded above. The classic hysteresis fields above stay explicit/typed.
+    if postprocess:
+        values["postprocess_params"] = dict(postprocess)
     return values

--- a/tests/test_heatmap_decode.py
+++ b/tests/test_heatmap_decode.py
@@ -1,0 +1,246 @@
+"""Runtime heatmap decode + multi-track windowed inference.
+
+Locks the torch-free runtime decode (infer.heatmap_decode) and the N-track
+windowed-average runner (infer.inference) that feed the boundary-heatmap
+production pipeline. The decode is a verbatim port of the training-side
+evaluator, so these mirror the shapes the offline six-bin numbers were measured
+on.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from infer.heatmap_decode import (
+    HeatmapDecodeConfig,
+    _merge_intervals,
+    _runs_above,
+    _soft_argmax_time,
+    decode_heatmap_segments,
+    decode_hybrid,
+    decode_peakpair,
+)
+from infer.inference import (
+    _order_heatmap_outputs,
+    run_multitrack_windowed_inference_stream,
+    run_windowed_inference_average_stream,
+)
+
+FPS = 5.0
+
+
+def _timestamps(n: int) -> np.ndarray:
+    return np.arange(n, dtype=np.float64) / FPS
+
+
+# ---------------------------------------------------------------- decode helpers
+
+
+def test_runs_above_finds_contiguous_runs():
+    prob = np.array([0.1, 0.9, 0.9, 0.1, 0.8, 0.1], dtype=np.float64)
+    assert _runs_above(prob, 0.5) == [(1, 2), (4, 4)]
+
+
+def test_runs_above_empty_when_all_below():
+    assert _runs_above(np.zeros(10), 0.5) == []
+
+
+def test_soft_argmax_single_spike_is_exact():
+    ts = _timestamps(20)
+    prob = np.zeros(20)
+    prob[5] = 0.9  # lone spike -> weighted mean is exactly that frame's time
+    assert _soft_argmax_time(prob, ts, center=5, window=5) == pytest.approx(ts[5])
+
+
+def test_soft_argmax_falls_back_to_center_time_when_no_mass():
+    ts = _timestamps(20)
+    prob = np.zeros(20)  # no heatmap mass anywhere
+    # mean of the window's timestamps [3..7] -> ts[5]
+    assert _soft_argmax_time(prob, ts, center=5, window=2) == pytest.approx(ts[3:8].mean())
+
+
+def test_soft_argmax_interpolates_between_frames():
+    ts = _timestamps(20)
+    prob = np.zeros(20)
+    prob[5] = 1.0
+    prob[6] = 1.0  # equal mass on two adjacent frames -> midpoint time
+    got = _soft_argmax_time(prob, ts, center=5, window=3)
+    assert got == pytest.approx((ts[5] + ts[6]) / 2)
+
+
+def test_merge_intervals_merges_touching_and_overlapping():
+    assert _merge_intervals([(0.0, 1.0), (1.0, 2.0), (5.0, 6.0)]) == [(0.0, 2.0), (5.0, 6.0)]
+    assert _merge_intervals([(0.0, 3.0), (1.0, 2.0)]) == [(0.0, 3.0)]
+    assert _merge_intervals([(2.0, 1.0)]) == []  # degenerate dropped
+
+
+# ---------------------------------------------------------------- hybrid decode
+
+
+def test_decode_hybrid_single_point_recovers_boundaries():
+    n = 20
+    ts = _timestamps(n)
+    pointness = np.full(n, 0.1)
+    pointness[5:11] = 0.9  # run frames 5..10
+    start_prob = np.zeros(n)
+    start_prob[5] = 0.9
+    end_prob = np.zeros(n)
+    end_prob[10] = 0.9
+    cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5)
+    segs = decode_hybrid(pointness, start_prob, end_prob, ts, cfg)
+    assert len(segs) == 1
+    assert segs[0] == pytest.approx((ts[5], ts[10]))
+
+
+def test_decode_hybrid_two_points_no_cross_pairing():
+    n = 24
+    ts = _timestamps(n)
+    pointness = np.full(n, 0.1)
+    pointness[3:6] = 0.9   # point A: frames 3..5
+    pointness[14:18] = 0.9  # point B: frames 14..17
+    start_prob = np.zeros(n)
+    start_prob[3] = 0.9
+    start_prob[14] = 0.9
+    end_prob = np.zeros(n)
+    end_prob[5] = 0.9
+    end_prob[17] = 0.9
+    cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5)
+    segs = decode_hybrid(pointness, start_prob, end_prob, ts, cfg)
+    assert len(segs) == 2
+    assert segs[0] == pytest.approx((ts[3], ts[5]))
+    assert segs[1] == pytest.approx((ts[14], ts[17]))
+
+
+def test_decode_hybrid_falls_back_to_run_edges_when_refine_inverts():
+    # start heatmap mass sits AFTER the end heatmap mass -> refined s>=e; decode
+    # must fall back to the raw run-edge timestamps rather than emit nothing/garbage.
+    n = 20
+    ts = _timestamps(n)
+    pointness = np.full(n, 0.1)
+    pointness[5:11] = 0.9
+    start_prob = np.zeros(n)
+    start_prob[10] = 0.9  # inverted: "start" peak at the run end
+    end_prob = np.zeros(n)
+    end_prob[5] = 0.9      # inverted: "end" peak at the run start
+    cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5)
+    segs = decode_hybrid(pointness, start_prob, end_prob, ts, cfg)
+    assert len(segs) == 1
+    assert segs[0] == pytest.approx((ts[5], ts[10]))  # raw run edges
+
+
+def test_decode_hybrid_no_points_returns_empty():
+    n = 20
+    ts = _timestamps(n)
+    cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5)
+    assert decode_hybrid(np.full(n, 0.1), np.zeros(n), np.zeros(n), ts, cfg) == []
+
+
+# -------------------------------------------------------------- peakpair decode
+
+
+def test_decode_peakpair_pairs_start_to_next_end():
+    n = 24
+    ts = _timestamps(n)
+    pointness = np.full(n, 0.9)
+    start_prob = np.zeros(n)
+    start_prob[4] = 0.9
+    end_prob = np.zeros(n)
+    end_prob[12] = 0.9
+    cfg = HeatmapDecodeConfig(mode="peakpair", peak_threshold=0.3, min_duration_sec=0.3)
+    segs = decode_peakpair(pointness, start_prob, end_prob, ts, cfg)
+    assert len(segs) == 1
+    assert segs[0] == pytest.approx((ts[4], ts[12]))
+
+
+def test_decode_peakpair_rejects_pairs_over_max_duration():
+    n = 40
+    ts = _timestamps(n)
+    pointness = np.full(n, 0.9)
+    start_prob = np.zeros(n)
+    start_prob[2] = 0.9
+    end_prob = np.zeros(n)
+    end_prob[38] = 0.9
+    # 36 frames / 5 fps = 7.2s > max 1.0s -> rejected
+    cfg = HeatmapDecodeConfig(mode="peakpair", peak_threshold=0.3, max_duration_sec=1.0)
+    assert decode_peakpair(pointness, start_prob, end_prob, ts, cfg) == []
+
+
+def test_decode_dispatch_unknown_mode_raises():
+    n = 10
+    ts = _timestamps(n)
+    cfg = HeatmapDecodeConfig(mode="nonsense")
+    with pytest.raises(ValueError, match="Unknown decode mode"):
+        decode_heatmap_segments(np.zeros(n), np.zeros(n), np.zeros(n), ts, cfg)
+
+
+# ------------------------------------------------- ONNX output ordering mapping
+
+
+def test_order_heatmap_outputs_by_name():
+    # scrambled export order -> remapped to [point, start, end]
+    names = ["end_heatmap_logit", "pointness_logit", "start_heatmap_logit"]
+    assert _order_heatmap_outputs(names) == [1, 2, 0]
+
+
+def test_order_heatmap_outputs_positional_fallback():
+    names = ["out0", "out1", "out2"]  # uninformative -> declared order
+    assert _order_heatmap_outputs(names) == [0, 1, 2]
+
+
+# ------------------------------------------------ multi-track windowed inference
+
+
+def test_multitrack_matches_single_track_for_one_track():
+    # The N-track runner must reduce to the single-track path exactly (same
+    # windowing + float32 accumulation) when K=1.
+    rng = np.random.default_rng(0)
+    rows = [rng.standard_normal(8).astype(np.float32) for _ in range(37)]
+    L, overlap = 10, 5
+
+    def win_1(window):  # [L, F] -> [L]
+        return window.sum(axis=1)
+
+    def win_k(window):  # [L, F] -> [1, L]
+        return window.sum(axis=1)[None, :]
+
+    single = run_windowed_inference_average_stream(list(rows), win_1, L, overlap)
+    multi = run_multitrack_windowed_inference_stream(list(rows), win_k, L, overlap, num_tracks=1)
+    assert multi.shape == (1, len(rows))
+    np.testing.assert_allclose(multi[0], single, rtol=0, atol=1e-6)
+
+
+def test_multitrack_averages_overlapping_windows():
+    # Constant per-track output per window; overlapped frames must average to the
+    # same constant, and the shape is (num_tracks, num_frames).
+    n, L, overlap = 25, 10, 5
+    rows = [np.ones(4, dtype=np.float32) for _ in range(n)]
+
+    def win_k(window):
+        # track t emits the constant (t+1) across the whole window
+        return np.stack([np.full(L, t + 1.0, dtype=np.float32) for t in range(3)], axis=0)
+
+    out = run_multitrack_windowed_inference_stream(list(rows), win_k, L, overlap, num_tracks=3)
+    assert out.shape == (3, n)
+    np.testing.assert_allclose(out[0], 1.0)
+    np.testing.assert_allclose(out[1], 2.0)
+    np.testing.assert_allclose(out[2], 3.0)
+
+
+def test_multitrack_rejects_bad_window_shape():
+    rows = [np.ones(4, dtype=np.float32) for _ in range(15)]
+
+    def bad_win(window):
+        return np.zeros((2, window.shape[0]))  # says 2 tracks, runner expects 3
+
+    with pytest.raises(ValueError, match="window output shape mismatch"):
+        run_multitrack_windowed_inference_stream(list(rows), bad_win, 10, 5, num_tracks=3)
+
+
+def test_multitrack_raises_when_video_too_short():
+    rows = [np.ones(4, dtype=np.float32) for _ in range(5)]  # < seq_len
+
+    def win_k(window):
+        return np.zeros((3, window.shape[0]), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="too short"):
+        run_multitrack_windowed_inference_stream(list(rows), win_k, 10, 5, num_tracks=3)

--- a/tests/test_heatmap_decode.py
+++ b/tests/test_heatmap_decode.py
@@ -86,10 +86,24 @@ def test_decode_hybrid_single_point_recovers_boundaries():
     start_prob[5] = 0.9
     end_prob = np.zeros(n)
     end_prob[10] = 0.9
+    # Run spans 5 frames @ 5fps = 1.0s > default min_duration_sec 0.3
     cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5)
     segs = decode_hybrid(pointness, start_prob, end_prob, ts, cfg)
     assert len(segs) == 1
     assert segs[0] == pytest.approx((ts[5], ts[10]))
+
+
+def test_decode_hybrid_drops_below_min_duration():
+    n = 20
+    ts = _timestamps(n)
+    pointness = np.full(n, 0.1)
+    pointness[5:7] = 0.9  # 2 frames @ 5fps = 0.2s
+    start_prob = np.zeros(n)
+    start_prob[5] = 0.9
+    end_prob = np.zeros(n)
+    end_prob[6] = 0.9
+    cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5, min_duration_sec=0.3)
+    assert decode_hybrid(pointness, start_prob, end_prob, ts, cfg) == []
 
 
 def test_decode_hybrid_two_points_no_cross_pairing():
@@ -104,7 +118,7 @@ def test_decode_hybrid_two_points_no_cross_pairing():
     end_prob = np.zeros(n)
     end_prob[5] = 0.9
     end_prob[17] = 0.9
-    cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5)
+    cfg = HeatmapDecodeConfig(mode="hybrid", threshold=0.5, min_duration_sec=0.0)
     segs = decode_hybrid(pointness, start_prob, end_prob, ts, cfg)
     assert len(segs) == 2
     assert segs[0] == pytest.approx((ts[3], ts[5]))
@@ -165,6 +179,30 @@ def test_decode_peakpair_rejects_pairs_over_max_duration():
     assert decode_peakpair(pointness, start_prob, end_prob, ts, cfg) == []
 
 
+def test_decode_peakpair_gate_does_not_consume_end_on_reject():
+    # First start+end pair fails the pointness gate; that end must remain
+    # available for a later start that passes the gate.
+    n = 40
+    ts = _timestamps(n)
+    pointness = np.full(n, 0.1)
+    pointness[20:30] = 0.9  # only the second interval has pointness mass
+    start_prob = np.zeros(n)
+    start_prob[4] = 0.9
+    start_prob[20] = 0.9
+    end_prob = np.zeros(n)
+    end_prob[12] = 0.9
+    end_prob[28] = 0.9
+    cfg = HeatmapDecodeConfig(
+        mode="peakpair",
+        peak_threshold=0.3,
+        min_duration_sec=0.3,
+        pointness_gate=0.5,
+    )
+    segs = decode_peakpair(pointness, start_prob, end_prob, ts, cfg)
+    assert len(segs) == 1
+    assert segs[0] == pytest.approx((ts[20], ts[28]))
+
+
 def test_decode_dispatch_unknown_mode_raises():
     n = 10
     ts = _timestamps(n)
@@ -182,9 +220,10 @@ def test_order_heatmap_outputs_by_name():
     assert _order_heatmap_outputs(names) == [1, 2, 0]
 
 
-def test_order_heatmap_outputs_positional_fallback():
-    names = ["out0", "out1", "out2"]  # uninformative -> declared order
-    assert _order_heatmap_outputs(names) == [0, 1, 2]
+def test_order_heatmap_outputs_rejects_uninformative_names():
+    names = ["out0", "out1", "out2"]
+    with pytest.raises(ValueError, match="missing a name containing"):
+        _order_heatmap_outputs(names)
 
 
 def test_order_heatmap_outputs_rejects_ambiguous_names():

--- a/tests/test_heatmap_decode.py
+++ b/tests/test_heatmap_decode.py
@@ -292,3 +292,89 @@ def test_multitrack_raises_when_video_too_short():
 
     with pytest.raises(ValueError, match="too short"):
         run_multitrack_windowed_inference_stream(list(rows), win_k, 10, 5, num_tracks=3)
+
+
+# --- hybrid false-positive filtering (smoothing + post-merge duration floor) ---
+# Mirrors tests/test_heatmap_tcn.py on the training side; these two decodes must
+# stay behaviourally identical for the offline six-bin numbers to transfer.
+
+
+def _fp_tracks(n: int = 60):
+    """Two real point runs plus a short spurious burst between them.
+
+    The burst is 3 frames (0.6s), not 1: a single-frame run collapses to s == e
+    and is already dropped by the `e > s` guard, so it would never exercise the
+    duration floor.
+    """
+    point = np.zeros(n, dtype=np.float32)
+    point[5:20] = 0.9
+    point[30:33] = 0.9
+    point[40:55] = 0.9
+    start = np.zeros(n, dtype=np.float32)
+    start[[5, 30, 40]] = 1.0
+    end = np.zeros(n, dtype=np.float32)
+    end[[19, 32, 54]] = 1.0
+    ts = np.arange(n, dtype=np.float64) / 5.0
+    return point, start, end, ts
+
+
+def _fp_cfg(**kw):
+    base = dict(mode="hybrid", threshold=0.5, sigma_frames=2.5,
+                min_duration_sec=0.3, max_duration_sec=60.0)
+    base.update(kw)
+    return HeatmapDecodeConfig(**base)
+
+
+def test_fp_filters_default_to_no_ops():
+    """Defaults must reproduce the previous hybrid behaviour, so results
+    measured before these knobs existed remain valid."""
+    cfg = _fp_cfg()
+    assert cfg.smooth_sigma_frames is None
+    assert cfg.hybrid_min_duration_sec == 0.0
+    point, start, end, ts = _fp_tracks()
+    assert len(decode_hybrid(point, start, end, ts, cfg)) == 3
+
+
+def test_duration_floor_drops_short_burst_keeps_real_points():
+    point, start, end, ts = _fp_tracks()
+    segs = decode_hybrid(point, start, end, ts, _fp_cfg(hybrid_min_duration_sec=1.0))
+    assert len(segs) == 2
+    assert all((e - s) >= 1.0 for s, e in segs)
+
+
+def test_smoothing_suppresses_isolated_burst():
+    point, start, end, ts = _fp_tracks()
+    assert len(decode_hybrid(point, start, end, ts, _fp_cfg(smooth_sigma_frames=2.5))) == 2
+
+
+def test_duration_floor_applies_after_merging():
+    """Adjacent fragments of one point must not be dropped individually."""
+    n = 40
+    point = np.zeros(n, dtype=np.float32)
+    point[10:20] = 0.9
+    start = np.zeros(n, dtype=np.float32)
+    start[10] = 1.0
+    end = np.zeros(n, dtype=np.float32)
+    end[19] = 1.0
+    ts = np.arange(n, dtype=np.float64) / 5.0
+    assert len(decode_hybrid(point, start, end, ts, _fp_cfg(hybrid_min_duration_sec=1.5))) == 1
+
+
+def test_gaussian_smooth_is_identity_for_non_positive_sigma():
+    from infer.heatmap_decode import _gaussian_smooth
+
+    data = np.array([0.0, 1.0, 0.0, 0.5], dtype=np.float32)
+    assert np.array_equal(_gaussian_smooth(data, 0.0), data)
+    assert _gaussian_smooth(data, 0.0) is not data  # must be a copy
+
+
+def test_gaussian_smooth_preserves_length_and_mass():
+    from infer.heatmap_decode import _gaussian_smooth
+
+    data = np.zeros(50, dtype=np.float32)
+    data[20:30] = 1.0
+    out = _gaussian_smooth(data, 2.0)
+    assert out.shape == data.shape
+    assert out.max() <= 1.0 + 1e-6
+    assert out[25] > 0.9  # plateau centre survives
+    assert out[10] < 0.05  # far field stays near zero

--- a/tests/test_heatmap_decode.py
+++ b/tests/test_heatmap_decode.py
@@ -187,6 +187,15 @@ def test_order_heatmap_outputs_positional_fallback():
     assert _order_heatmap_outputs(names) == [0, 1, 2]
 
 
+def test_order_heatmap_outputs_rejects_ambiguous_names():
+    # 'start_end_scores' contains both 'start' and 'end' -> two keys resolve to
+    # the same output; silently aliasing tracks would corrupt boundaries, so the
+    # mapping must fail loudly instead.
+    names = ["pointness", "start_end_scores", "aux"]
+    with pytest.raises(ValueError, match="Ambiguous heatmap ONNX output names"):
+        _order_heatmap_outputs(names)
+
+
 # ------------------------------------------------ multi-track windowed inference
 
 

--- a/tests/test_heatmap_runtime.py
+++ b/tests/test_heatmap_runtime.py
@@ -240,6 +240,47 @@ def test_heatmap_model_segments_video_from_intervals(tmp_path, monkeypatch):
     assert intervals == result.intervals_sec == [pytest.approx((4 / FPS, 8 / FPS))]
 
 
+def test_heatmap_model_uses_injected_deps_over_module_import(tmp_path, monkeypatch):
+    # When RuntimeDeps carries the heatmap slots (as the engine's default loader
+    # wires them), the model must use them -- not the bare `infer` module import.
+    n = 20
+    point = np.full(n, 0.1, dtype=np.float32)
+    point[5:11] = 0.9
+    start = np.zeros(n, dtype=np.float32)
+    start[5] = 0.9
+    end = np.zeros(n, dtype=np.float32)
+    end[10] = 0.9
+    tracks = np.stack([point, start, end], axis=0)
+
+    monkeypatch.setattr(
+        engine_models, "build_feature_stream",
+        lambda request, deps, pcb, ccb: [(np.zeros(4, dtype=np.float32), 0) for _ in range(n)],
+    )
+    # Deliberately do NOT patch the infer module: if the model bypassed deps and
+    # imported the real runner, it would choke on the fake model bytes.
+    from dataclasses import replace as dc_replace
+
+    from infer import HeatmapDecodeConfig, decode_heatmap_segments
+
+    ran_via_deps = []
+
+    def fake_runner(*a, **k):
+        ran_via_deps.append(True)
+        return tracks
+
+    deps = _fake_deps()
+    deps.run_multitrack_windowed_inference_onnx_stream = fake_runner
+    deps.decode_heatmap_segments = decode_heatmap_segments
+    deps.heatmap_decode_config_cls = HeatmapDecodeConfig
+
+    request = _make_request(tmp_path, write_csv=False)
+    model = build_analysis_model(request, _spec(tmp_path), deps)
+    result = model.run()
+
+    assert ran_via_deps == [True]
+    assert result.intervals_sec == [pytest.approx((5 / FPS, 10 / FPS))]
+
+
 def test_heatmap_model_rejects_non_onnx(tmp_path, monkeypatch):
     _install_fakes(monkeypatch, np.zeros((3, 12), dtype=np.float32))
     from rallyclip_core.contracts import UnsupportedPipelineError

--- a/tests/test_heatmap_runtime.py
+++ b/tests/test_heatmap_runtime.py
@@ -1,0 +1,251 @@
+"""HeatmapHybridModel wiring + heatmap pipeline resolution.
+
+Covers the engine-side glue that the pure-decode unit tests (test_heatmap_decode)
+do not: manifest -> PipelineSpec resolution, dispatch to HeatmapHybridModel, and
+the full model.run() producing float-second intervals + a segments CSV. The pose
+feature stream and the ONNX runner are faked so this needs no video or model
+artifact.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rallyclip_core.contracts import RunRequest, RuntimeDeps
+from rallyclip_core.pipelines import (
+    FRAME_STARTEND_HEATMAP,
+    resolve_pipeline_spec,
+)
+from rallyclip_engine import models as engine_models
+from rallyclip_engine.models import HeatmapHybridModel, build_analysis_model
+
+FPS = 5.0
+
+
+# --------------------------------------------------------- pipeline resolution
+
+
+def _write_heatmap_manifest(tmp_path: Path) -> tuple[Path, Path]:
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"not a real onnx")  # only the suffix matters here
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "pipeline": {"id": "frame_startend_heatmap"},
+                "feature_pipeline": {"feature_set": "v1", "target_fps": FPS},
+                "inference": {"seq_len_frames": 100, "overlap_frames": 50},
+                "model": {"outputs": ["pointness_logit", "start_heatmap_logit", "end_heatmap_logit"]},
+                "postprocess": {
+                    "method": "heatmap_hybrid",
+                    "params": {
+                        "mode": "hybrid",
+                        "threshold": 0.5,
+                        "sigma_frames": 2.5,
+                        "min_duration_sec": 0.3,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return model_path, manifest_path
+
+
+def test_resolve_pipeline_spec_from_heatmap_manifest(tmp_path):
+    model_path, manifest_path = _write_heatmap_manifest(tmp_path)
+    spec = resolve_pipeline_spec(model_path, manifest_path)
+    assert spec.pipeline_id == FRAME_STARTEND_HEATMAP
+    assert spec.model_output == "pointness_start_end_heatmap"
+    assert spec.decode_method == "heatmap_hybrid"
+    assert spec.feature_set == "v1"
+    # decode knobs flow through from postprocess.params
+    assert spec.params["mode"] == "hybrid"
+    assert spec.params["sigma_frames"] == 2.5
+    assert spec.params["min_duration_sec"] == 0.3
+
+
+def test_resolve_pipeline_spec_via_method_only(tmp_path):
+    # No explicit pipeline.id -> the postprocess.method selects the heatmap pipeline.
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"x")
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "feature_pipeline": {"feature_set": "v1", "target_fps": FPS},
+                "inference": {"seq_len_frames": 100, "overlap_frames": 50},
+                "postprocess": {"method": "heatmap_hybrid", "params": {"threshold": 0.4}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    spec = resolve_pipeline_spec(model_path, manifest_path)
+    assert spec.pipeline_id == FRAME_STARTEND_HEATMAP
+    assert spec.params["threshold"] == 0.4
+
+
+def test_heatmap_override_incompatible_with_classic_manifest(tmp_path):
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"x")
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "feature_pipeline": {"feature_set": "v1", "target_fps": FPS},
+                "inference": {"seq_len_frames": 100, "overlap_frames": 50},
+                "postprocess": {"method": "hysteresis", "params": {"sigma": 1.5, "low": 0.5, "high": 0.65}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    from rallyclip_core.contracts import UnsupportedPipelineError
+
+    with pytest.raises(UnsupportedPipelineError):
+        resolve_pipeline_spec(model_path, manifest_path, override_pipeline_id=FRAME_STARTEND_HEATMAP)
+
+
+# ----------------------------------------------------------- full model.run()
+
+
+class _IdentityScaler:
+    def transform(self, values):
+        return np.asarray(values, dtype=np.float32)
+
+
+def _make_request(tmp_path: Path, *, write_csv=True, segment_video=False) -> RunRequest:
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"x")
+    return RunRequest(
+        video_path=tmp_path / "match.mp4",
+        output_dir=tmp_path / "out",
+        output_name="match",
+        csv_output_dir=tmp_path / "out",
+        write_csv=write_csv,
+        segment_video=segment_video,
+        yolo_weights="yolov8n-pose-960-dynamic.onnx",
+        yolo_device=None,
+        model_path=model_path,
+        scaler_path=tmp_path / "scaler.json",
+        fps=FPS,
+        seq_len=10,
+        imgsz=960,
+        conf=0.25,
+        feature_set="v1",
+        screen_width=1280,
+        screen_height=720,
+        overlap=5,
+        sigma=0.0,
+        low=0.0,
+        high=0.0,
+        min_dur_sec=0.0,
+        pipeline_id=FRAME_STARTEND_HEATMAP,
+    )
+
+
+def _fake_deps(segment_calls=None) -> RuntimeDeps:
+    def fake_segment_video(video, intervals, out):
+        if segment_calls is not None:
+            segment_calls.append((video, intervals, out))
+
+    return RuntimeDeps(
+        np=np,
+        PoseExtractor=None,
+        DataPreprocessor=None,
+        FeatureEngineer=None,
+        load_scaler_asset=lambda path: _IdentityScaler(),
+        load_model_from_checkpoint=None,
+        run_windowed_inference_average_onnx_stream=None,
+        run_windowed_inference_average_torch_stream=None,
+        gaussian_filter1d=None,
+        hysteresis_threshold=None,
+        extract_segments_from_binary=None,
+        write_segments_csv=lambda *a, **k: None,
+        segment_video=fake_segment_video,
+    )
+
+
+def _spec(tmp_path, params=None):
+    _model, manifest = _write_heatmap_manifest(tmp_path)
+    spec = resolve_pipeline_spec(tmp_path / "model.onnx", manifest)
+    if params is not None:
+        # rebuild with overridden decode params
+        from dataclasses import replace
+
+        spec = replace(spec, params=params)
+    return spec
+
+
+def _install_fakes(monkeypatch, tracks):
+    # bypass the heavy pose->feature stream
+    monkeypatch.setattr(
+        engine_models, "build_feature_stream",
+        lambda request, deps, pcb, ccb: [(np.zeros(4, dtype=np.float32), 0) for _ in range(len(tracks[0]))],
+    )
+    # the ONNX runner returns our synthetic (3, N) tracks regardless of inputs
+    import infer
+
+    monkeypatch.setattr(
+        infer, "run_multitrack_windowed_inference_onnx_stream",
+        lambda *a, **k: np.asarray(tracks, dtype=np.float32),
+    )
+
+
+def test_heatmap_model_run_produces_intervals_and_csv(tmp_path, monkeypatch):
+    n = 20
+    point = np.full(n, 0.1, dtype=np.float32)
+    point[5:11] = 0.9  # run frames 5..10
+    start = np.zeros(n, dtype=np.float32)
+    start[5] = 0.9
+    end = np.zeros(n, dtype=np.float32)
+    end[10] = 0.9
+    _install_fakes(monkeypatch, np.stack([point, start, end], axis=0))
+
+    request = _make_request(tmp_path)
+    spec = _spec(tmp_path)
+    model = build_analysis_model(request, spec, _fake_deps())
+    assert isinstance(model, HeatmapHybridModel)
+
+    result = model.run()
+
+    assert result.intervals_sec == [pytest.approx((5 / FPS, 10 / FPS))]
+    assert result.frame_segments == [(5, 10)]  # rounded, for RunResult consumers
+    assert result.diagnostics["pipeline_id"] == FRAME_STARTEND_HEATMAP
+    # CSV written in the segments.csv contract, sub-frame precision preserved
+    csv_text = (tmp_path / "out" / "match_segments.csv").read_text(encoding="utf-8")
+    assert csv_text.splitlines()[0] == "start_time,end_time"
+    assert csv_text.splitlines()[1] == "1.000,2.000"
+
+
+def test_heatmap_model_segments_video_from_intervals(tmp_path, monkeypatch):
+    n = 16
+    point = np.full(n, 0.1, dtype=np.float32)
+    point[4:9] = 0.9
+    start = np.zeros(n, dtype=np.float32)
+    start[4] = 0.9
+    end = np.zeros(n, dtype=np.float32)
+    end[8] = 0.9
+    _install_fakes(monkeypatch, np.stack([point, start, end], axis=0))
+
+    calls = []
+    request = _make_request(tmp_path, write_csv=False, segment_video=True)
+    model = build_analysis_model(request, _spec(tmp_path), _fake_deps(segment_calls=calls))
+    result = model.run()
+
+    assert len(calls) == 1
+    _video, intervals, _out = calls[0]
+    assert intervals == result.intervals_sec == [pytest.approx((4 / FPS, 8 / FPS))]
+
+
+def test_heatmap_model_rejects_non_onnx(tmp_path, monkeypatch):
+    _install_fakes(monkeypatch, np.zeros((3, 12), dtype=np.float32))
+    from rallyclip_core.contracts import UnsupportedPipelineError
+
+    request = _make_request(tmp_path)
+    object.__setattr__(request, "model_path", tmp_path / "model.pth")  # frozen dataclass
+    model = build_analysis_model(request, _spec(tmp_path), _fake_deps())
+    with pytest.raises(UnsupportedPipelineError, match="ONNX models only"):
+        model.run()


### PR DESCRIPTION
## Summary
- Rebase of #45 onto current `main` (includes v0.4.0 classic default + CUDA extras).
- Runtime-only: `HeatmapHybridModel` + hybrid/peakpair decode. Classic v0.4.0 remains the default artifact.
- No model bundle or default swap in this PR.

## Test plan
- [x] `pytest tests/test_heatmap_decode.py tests/test_heatmap_runtime.py` (35 passed)
- [ ] CI green on this branch

Closes the rebase gap that made #45 unmergeable against post-v0.4.0 main. Original #45 can be closed after this lands.

Made with [Cursor](https://cursor.com)