### PR TITLE
Fix Release GUI probe: Flask first, still boot WKWebView

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
 
           # Boot the packaged GUI personality: Flask + pywebview (WKWebView).
           # Health can come up before the window; "desktop shell ready" is printed
-          # after create_window and is the check that pywebview actually loaded.
+          # from window.events.loaded after WKWebView has loaded the Flask page.
           export RALLYCLIP_GUI_PORT=8765
           export PYTHONUNBUFFERED=1
           "$BIN" > gui_probe.log 2>&1 &
@@ -151,7 +151,11 @@ jobs:
             sleep 2
           done
           if [ -n "$ok" ]; then
-            curl -s -m 5 http://127.0.0.1:8765/api/config/defaults | grep -q "yolov8n-pose-960-dynamic.onnx" || ok=""
+            if ! kill -0 "$GUI_PID" 2>/dev/null; then
+              ok=""
+            elif ! curl -s -m 5 http://127.0.0.1:8765/api/config/defaults | grep -q "yolov8n-pose-960-dynamic.onnx"; then
+              ok=""
+            fi
           fi
           kill $GUI_PID 2>/dev/null || true
           if [ -z "$ok" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
           # Boot the GUI personality and prove Flask + the system webview
           # (WKWebView) come up in the frozen bundle.
           export RALLYCLIP_GUI_PORT=8765
-          "$BIN" > gui_probe.log 2>&1 &
+          "$BIN" --backend-only > gui_probe.log 2>&1 &
           GUI_PID=$!
           ok=""
           for i in $(seq 1 60); do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,19 +129,25 @@ jobs:
             --write-csv --csv-output-dir ./csv_out --no-segment-video
           test -f csv_out/smoke_segments.csv
           head -1 csv_out/smoke_segments.csv | grep -q "start_time,end_time"
-      - name: Probe GUI backend boot
+      - name: Probe packaged GUI boot
         shell: bash
         run: |
           BIN="$(pwd)/dist/RallyClip.app/Contents/MacOS/RallyClip"
 
-          # Boot the GUI personality and prove Flask + the system webview
-          # (WKWebView) come up in the frozen bundle.
+          # Boot the packaged GUI personality: Flask + pywebview (WKWebView).
+          # Health can come up before the window; "desktop shell ready" is printed
+          # after create_window and is the check that pywebview actually loaded.
           export RALLYCLIP_GUI_PORT=8765
-          "$BIN" --backend-only > gui_probe.log 2>&1 &
+          export PYTHONUNBUFFERED=1
+          "$BIN" > gui_probe.log 2>&1 &
           GUI_PID=$!
           ok=""
           for i in $(seq 1 60); do
-            if curl -s -m 2 http://127.0.0.1:8765/api/health | grep -q '"ok"'; then ok=1; break; fi
+            if curl -s -m 2 http://127.0.0.1:8765/api/health | grep -q '"ok"' \
+              && grep -q "RallyClip desktop shell ready" gui_probe.log; then
+              ok=1
+              break
+            fi
             sleep 2
           done
           if [ -n "$ok" ]; then

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -185,3 +185,16 @@ Format per entry: date — what / why / rejected alternative. Never rewrite old 
   the Mac app; putting weights in Application Support next to the library;
   rewriting git history in the same change.
 
+## 2026-09-08 — Release probe boots the real GUI, Flask first
+
+- **What:** Packaged release CI launches `"$BIN"` (no `--backend-only`). Flask
+  starts and `/api/health` can succeed before pywebview/WKWebView is imported.
+  After `create_window`, the binary prints `RallyClip desktop shell ready`; the
+  probe requires that line plus health. `--backend-only` stays as a debug flag.
+- **Why:** v0.5.0 release failed because importing WKWebView on the GitHub
+  Mac runner stalled before Flask came up (30s). Switching the probe to
+  `--backend-only` would not catch a broken pywebview bundle (Greptile P2;
+  agreed).
+- **Rejected:** Keep `--backend-only` as the release probe (misses desktop-shell
+  regressions); importing webview before starting Flask (original hang).
+

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -198,3 +198,12 @@ Format per entry: date — what / why / rejected alternative. Never rewrite old 
 - **Rejected:** Keep `--backend-only` as the release probe (misses desktop-shell
   regressions); importing webview before starting Flask (original hang).
 
+## 2026-09-08 — Ready marker is `window.events.loaded`
+
+- **What:** `RallyClip desktop shell ready` prints from `window.events.loaded`
+  (DOM ready in WKWebView). Release probe also `kill -0`s the process after
+  seeing the line. `create_window()` only allocates the Python Window object.
+- **Why:** Greptile P1: a marker before `webview.start()` can pass while native
+  GUI init still fails; CI then kills the process.
+- **Rejected:** Printing after `create_window()` / before `webview.start()`.
+

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,34 +1,33 @@
 # PROGRESS — overwrite me at every session end
 
-_Last updated: 2026-09-07 (session: artifact-registry implementation)._
+_Last updated: 2026-09-08 (session: release GUI probe covers WKWebView)._
 
 ## Repo state
 
-- `main` includes merged macOS release CI (#50). GitHub Releases latest app
-  channel is still **v0.3.0**. Do not tag app `v0.5.0` until this lands on
-  `main` (and you want the DMG).
+- `main` includes artifact-registry (#53). GitHub Releases latest app channel
+  is still **v0.3.0**. Tag `v0.5.0` still points at the July docs commit —
+  do not move it until this GUI-probe fix is on `main`.
 - Artifact zip is **published** (not draft):
   https://github.com/iroblesrazzaq/RallyClip/releases/tag/artifact-rallyclip_v0.5.0
-- Active feature: `artifact-registry` (`docs/artifact-registry-plan.md`).
+- Active PR: https://github.com/iroblesrazzaq/RallyClip/pull/54
+  (`cursor/fix-gui-probe-5f28`). Release CI must boot the real packaged GUI
+  (Flask first, then pywebview); `--backend-only` is not the probe.
 
 ## What shipped this session
 
-1. `src/runtime/artifact.py` + `scripts/fetch_artifact.py` +
-   `scripts/release/pack_artifact.sh`: pack/verify/fetch with SHA-256, zip-slip
-   reject, idempotent no-op when checksums match. Fail closed on mismatch.
-2. Published `artifact-rallyclip_v0.5.0` / `rallyclip_v0.5.0.zip` while weights
-   were still in git.
-3. `ci.yml` and `release.yml` fetch after install; release verify calls
-   `verify_artifact_dir` before PyInstaller. `RallyClip.spec` unchanged — DMG
-   still embeds `models/rallyclip_v0.5.0/`; frozen app does not fetch at launch.
-4. Gitignore ONNX + `scaler.json` under `models/`; dropped old/duplicate
-   weights from git; tests that only need pipeline id read `manifest.json`.
-5. Default gate: **298 passed, 6 skipped, 27 deselected, ~19s**.
-   Fetch unpacks to a temp dir and copies into `models/rallyclip_v0.5.0/`
-   only after SHA-256 verify (rejected zip cannot overwrite SHA256SUMS).
+1. GUI path starts Flask and waits for `/api/health` before importing
+   pywebview, so a slow WKWebView cannot starve the backend (root cause of
+   run 34176081009: `RallyClip backend failed to start.`).
+2. Release probe launches `"$BIN"` (no `--backend-only`) and requires the
+   log line `RallyClip desktop shell ready` after `create_window`, plus
+   health and the defaults ONNX name.
+3. `--backend-only` remains a debug flag. Dispatch tests stub Flask for the
+   GUI path, fake webview for the ready-line contract, and import `gui.app`
+   in a fresh interpreter with webview blocked.
+4. Default gate: **301 passed, 6 skipped, 27 deselected, ~20s**.
 
 ## Next steps
 
-1. Merge this PR. Then tag app `v0.5.0` when ready (fetch same zip, existing
-   sign/notary path).
-2. In-app Skip/Later auto-update remains out of scope.
+1. Greptile 5/5 on PR #54, then user merges.
+2. Move tag `v0.5.0` onto the new `main` and force-push the tag to re-run
+   Release (do not re-upload `artifact-rallyclip_v0.5.0`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -18,13 +18,13 @@ _Last updated: 2026-09-08 (session: release GUI probe covers WKWebView)._
 1. GUI path starts Flask and waits for `/api/health` before importing
    pywebview, so a slow WKWebView cannot starve the backend (root cause of
    run 34176081009: `RallyClip backend failed to start.`).
-2. Release probe launches `"$BIN"` (no `--backend-only`) and requires the
-   log line `RallyClip desktop shell ready` after `create_window`, plus
-   health and the defaults ONNX name.
+2. Release probe launches `"$BIN"` (no `--backend-only`) and requires
+   `window.events.loaded` to print `RallyClip desktop shell ready` (WKWebView
+   loaded the Flask page), then `kill -0` plus defaults ONNX name.
 3. `--backend-only` remains a debug flag. Dispatch tests stub Flask for the
    GUI path, fake webview for the ready-line contract, and import `gui.app`
    in a fresh interpreter with webview blocked.
-4. Default gate: **301 passed, 6 skipped, 27 deselected, ~20s**.
+4. Default gate: **302 passed, 6 skipped, 27 deselected, ~20s**.
 
 ## Next steps
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,8 +16,8 @@ equivalent alternative; `.venv-train` is what was verified 2026-07-03.)
 PYTHONPATH=src:tests $PY -m pytest -q -m "not slow and not e2e" -p no:cacheprovider
 ```
 
-Last known (2026-09-08, GUI --backend-only probe, Linux py3.12):
-**299 passed, 6 skipped, 27 deselected, ~19s**. `tests/test_release_packaging.py` 21 passed;
+Last known (2026-09-08, Flask-first GUI probe + desktop shell ready, Linux py3.12):
+**301 passed, 6 skipped, 27 deselected, ~20s**. `tests/test_release_packaging.py` 21 passed;
 `tests/test_artifact_fetch.py` 6 passed.
 
 ## Compile gate (cheap, run with the default gate)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,8 +16,8 @@ equivalent alternative; `.venv-train` is what was verified 2026-07-03.)
 PYTHONPATH=src:tests $PY -m pytest -q -m "not slow and not e2e" -p no:cacheprovider
 ```
 
-Last known (2026-09-07, artifact-registry fetch staging, Linux py3.12):
-**298 passed, 6 skipped, 27 deselected, ~19s**. `tests/test_release_packaging.py` 21 passed;
+Last known (2026-09-08, GUI --backend-only probe, Linux py3.12):
+**299 passed, 6 skipped, 27 deselected, ~19s**. `tests/test_release_packaging.py` 21 passed;
 `tests/test_artifact_fetch.py` 6 passed.
 
 ## Compile gate (cheap, run with the default gate)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,8 +16,8 @@ equivalent alternative; `.venv-train` is what was verified 2026-07-03.)
 PYTHONPATH=src:tests $PY -m pytest -q -m "not slow and not e2e" -p no:cacheprovider
 ```
 
-Last known (2026-09-08, Flask-first GUI probe + desktop shell ready, Linux py3.12):
-**301 passed, 6 skipped, 27 deselected, ~20s**. `tests/test_release_packaging.py` 21 passed;
+Last known (2026-09-08, loaded-event GUI probe, Linux py3.12):
+**302 passed, 6 skipped, 27 deselected, ~20s**. `tests/test_release_packaging.py` 21 passed;
 `tests/test_artifact_fetch.py` 6 passed.
 
 ## Compile gate (cheap, run with the default gate)

--- a/features.json
+++ b/features.json
@@ -59,7 +59,7 @@
       "name": "CI/CD builds, signs, notarizes, and uploads the macOS desktop DMG",
       "status": "passing",
       "verification": "PYTHONPATH=src:tests $PY -m pytest -q tests/test_release_packaging.py -p no:cacheprovider",
-      "evidence": "2026-09-08: release.yml probe launches the packaged GUI binary (not --backend-only). Flask starts before pywebview import; probe requires /api/health plus log line 'RallyClip desktop shell ready' after create_window. tests/test_release_packaging.py 21 passed. Default gate 301 passed, 6 skipped, 27 deselected."
+      "evidence": "2026-09-08: release.yml probe launches the packaged GUI binary (not --backend-only). Flask starts before pywebview import; probe requires /api/health plus log line 'RallyClip desktop shell ready' from window.events.loaded (WKWebView DOM ready), then kill -0. tests/test_release_packaging.py 21 passed. Default gate 302 passed, 6 skipped, 27 deselected."
     },
     {
       "id": "webview-shell",

--- a/features.json
+++ b/features.json
@@ -59,7 +59,7 @@
       "name": "CI/CD builds, signs, notarizes, and uploads the macOS desktop DMG",
       "status": "passing",
       "verification": "PYTHONPATH=src:tests $PY -m pytest -q tests/test_release_packaging.py -p no:cacheprovider",
-      "evidence": "2026-09-07: rebased onto v0.5.0 main. release.yml tags v* run tests, fetch artifact-rallyclip_v0.5.0, pyinstaller RallyClip.spec (bundles DEFAULT_ARTIFACT_DIR=models/rallyclip_v0.5.0 + CFBundleIdentifier com.iroblesrazzaq.rallyclip), sign/DMG/notarytool/staple via scripts/release/, and upload RallyClip-<version>-macOS-arm64.dmg to a draft GitHub Release. tests/test_release_packaging.py 21 passed (spec lockstep, fetch/verify wiring, gitignore, no tracked ONNX)."
+      "evidence": "2026-09-08: release.yml probe launches the packaged GUI binary (not --backend-only). Flask starts before pywebview import; probe requires /api/health plus log line 'RallyClip desktop shell ready' after create_window. tests/test_release_packaging.py 21 passed. Default gate 301 passed, 6 skipped, 27 deselected."
     },
     {
       "id": "webview-shell",

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -2691,18 +2691,23 @@ def start_backend_thread(port: Optional[int] = None) -> tuple[int, threading.Thr
     chosen_port = _choose_gui_port(port)
 
     def _serve() -> None:
-        app.run(host="127.0.0.1", port=chosen_port, debug=False, use_reloader=False, threaded=True)
+        try:
+            app.run(host="127.0.0.1", port=chosen_port, debug=False, use_reloader=False, threaded=True)
+        except Exception:
+            logging.exception("Flask backend crashed on port %s", chosen_port)
+            raise
 
     thread = threading.Thread(target=_serve, daemon=True, name="rallyclip-gui-backend")
     thread.start()
     return chosen_port, thread
 
 
-def launch(port: Optional[int] = None) -> int:
+def launch(port: Optional[int] = None, *, open_browser: bool = True) -> int:
     _configure_gui_logging()
     threading.Thread(target=_sweep_old_jobs, daemon=True, name="rallyclip-job-sweep").start()
     chosen_port = _choose_gui_port(port)
-    threading.Thread(target=_safe_open_browser, args=(chosen_port,), daemon=True).start()
+    if open_browser:
+        threading.Thread(target=_safe_open_browser, args=(chosen_port,), daemon=True).start()
     app.logger.info("Starting GUI on http://127.0.0.1:%s", chosen_port)
     try:
         app.run(host="127.0.0.1", port=chosen_port, debug=False, use_reloader=False, threaded=True)

--- a/src/gui/desktop.py
+++ b/src/gui/desktop.py
@@ -7,9 +7,10 @@ OS media stack, so the frontend's plain HTML5 <video> path is used (the old
 QtWebEngine shell needed a separate Qt-Multimedia native player because
 Chromium ships without proprietary codecs).
 
-The frozen binary also dispatches two headless personalities:
+The frozen binary also dispatches headless personalities:
     RallyClip --cli ...              # full analysis CLI (cli.main)
     RallyClip --analysis-worker ...  # GUI job subprocess
+    RallyClip --backend-only        # Flask only (no webview; CI probe)
 """
 
 from __future__ import annotations
@@ -47,6 +48,13 @@ def main() -> int:
 
         sys.argv = [sys.argv[0], *sys.argv[2:]]
         return cli_main(force_cli=True)
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--backend-only":
+        # Headless Flask for CI. Skip pywebview — WKWebView needs a window
+        # server and can stall backend boot on GitHub-hosted macOS.
+        from gui.app import launch
+
+        return launch(open_browser=False)
 
     try:
         import webview

--- a/src/gui/desktop.py
+++ b/src/gui/desktop.py
@@ -125,7 +125,13 @@ def main() -> int:
         min_size=(960, 600),
         js_api=api,
     )
-    print("RallyClip desktop shell ready", flush=True)
+
+    def _on_dom_ready() -> None:
+        # Fired after WKWebView has loaded the Flask page — not after
+        # create_window(), which only allocates the Python Window object.
+        print("RallyClip desktop shell ready", flush=True)
+
+    api.window.events.loaded += _on_dom_ready
     webview.start()
     return 0
 

--- a/src/gui/desktop.py
+++ b/src/gui/desktop.py
@@ -10,7 +10,7 @@ Chromium ships without proprietary codecs).
 The frozen binary also dispatches headless personalities:
     RallyClip --cli ...              # full analysis CLI (cli.main)
     RallyClip --analysis-worker ...  # GUI job subprocess
-    RallyClip --backend-only        # Flask only (no webview; CI probe)
+    RallyClip --backend-only        # Flask only (no webview)
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ import urllib.error
 import urllib.request
 
 
-def _wait_for_backend(port: int, timeout_sec: float = 30.0) -> bool:
+def _wait_for_backend(port: int, timeout_sec: float = 60.0) -> bool:
     deadline = time.time() + timeout_sec
     url = f"http://127.0.0.1:{port}/api/health"
     while time.time() < deadline:
@@ -50,11 +50,18 @@ def main() -> int:
         return cli_main(force_cli=True)
 
     if len(sys.argv) > 1 and sys.argv[1] == "--backend-only":
-        # Headless Flask for CI. Skip pywebview — WKWebView needs a window
-        # server and can stall backend boot on GitHub-hosted macOS.
+        # Flask without a window. Release CI still boots the real GUI path.
         from gui.app import launch
 
         return launch(open_browser=False)
+
+    # Flask first so /api/health is up even if WKWebView is slow to import.
+    from gui.app import start_backend_thread
+
+    port, _thread = start_backend_thread()
+    if not _wait_for_backend(port):
+        print("RallyClip backend failed to start.", file=sys.stderr)
+        return 1
 
     try:
         import webview
@@ -64,13 +71,6 @@ def main() -> int:
             file=sys.stderr,
         )
         print(f"Details: {exc}", file=sys.stderr)
-        return 1
-
-    from gui.app import start_backend_thread
-
-    port, _thread = start_backend_thread()
-    if not _wait_for_backend(port):
-        print("RallyClip backend failed to start.", file=sys.stderr)
         return 1
 
     # "Export video" / "Download CSV" navigate to Content-Disposition
@@ -125,6 +125,7 @@ def main() -> int:
         min_size=(960, 600),
         js_api=api,
     )
+    print("RallyClip desktop shell ready", flush=True)
     webview.start()
     return 0
 

--- a/tests/test_desktop_dispatch.py
+++ b/tests/test_desktop_dispatch.py
@@ -64,3 +64,20 @@ def test_no_args_takes_gui_path(monkeypatch):
 
     assert desktop.main() == 1
     assert "argv" not in calls
+
+
+def test_backend_only_skips_webview(monkeypatch):
+    launched: dict = {}
+
+    def fake_launch(*, open_browser: bool = True) -> int:
+        launched["open_browser"] = open_browser
+        return 0
+
+    import gui.app as gui_app
+
+    monkeypatch.setattr(gui_app, "launch", fake_launch)
+    _block_webview(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["RallyClip", "--backend-only"])
+
+    assert desktop.main() == 0
+    assert launched["open_browser"] is False

--- a/tests/test_desktop_dispatch.py
+++ b/tests/test_desktop_dispatch.py
@@ -83,11 +83,18 @@ def test_no_args_takes_gui_path(monkeypatch):
     assert "argv" not in calls
 
 
-def test_gui_path_creates_window_then_starts(monkeypatch, capsys):
-    _stub_backend(monkeypatch)
+class _FakeLoaded:
+    def __init__(self) -> None:
+        self.handlers: list = []
+
+    def __iadd__(self, handler):
+        self.handlers.append(handler)
+        return self
+
+
+def _install_fake_webview(monkeypatch, *, fire_loaded: bool):
     created: dict = {}
     started: list = []
-
     fake = types.ModuleType("webview")
     fake.settings = {}
 
@@ -95,11 +102,26 @@ def test_gui_path_creates_window_then_starts(monkeypatch, capsys):
         created["title"] = title
         created["url"] = url
         created["kwargs"] = kwargs
-        return types.SimpleNamespace(uid="w1")
+        created["window"] = types.SimpleNamespace(
+            uid="w1", events=types.SimpleNamespace(loaded=_FakeLoaded())
+        )
+        return created["window"]
+
+    def start(func=None, args=None, **kwargs):
+        started.append(True)
+        if fire_loaded:
+            for handler in created["window"].events.loaded.handlers:
+                handler()
 
     fake.create_window = create_window
-    fake.start = lambda: started.append(True)
+    fake.start = start
     monkeypatch.setitem(sys.modules, "webview", fake)
+    return created, started
+
+
+def test_gui_path_creates_window_then_starts(monkeypatch, capsys):
+    _stub_backend(monkeypatch)
+    created, started = _install_fake_webview(monkeypatch, fire_loaded=True)
     monkeypatch.setattr(sys, "argv", ["RallyClip"])
 
     assert desktop.main() == 0
@@ -107,6 +129,15 @@ def test_gui_path_creates_window_then_starts(monkeypatch, capsys):
     assert created["url"] == "http://127.0.0.1:8765/"
     assert started == [True]
     assert "RallyClip desktop shell ready" in capsys.readouterr().out
+
+
+def test_gui_ready_line_waits_for_webview_loaded(monkeypatch, capsys):
+    _stub_backend(monkeypatch)
+    _install_fake_webview(monkeypatch, fire_loaded=False)
+    monkeypatch.setattr(sys, "argv", ["RallyClip"])
+
+    assert desktop.main() == 0
+    assert "RallyClip desktop shell ready" not in capsys.readouterr().out
 
 
 def test_backend_only_skips_webview(monkeypatch):

--- a/tests/test_desktop_dispatch.py
+++ b/tests/test_desktop_dispatch.py
@@ -1,9 +1,16 @@
+"""CLI vs GUI dispatch for the frozen Mac app."""
+
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 import types
+from pathlib import Path
 
 import gui.desktop as desktop
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _stub_cli_main(monkeypatch, result: int = 0) -> dict:
@@ -24,6 +31,20 @@ def _stub_cli_main(monkeypatch, result: int = 0) -> dict:
     return calls
 
 
+def _block_webview(monkeypatch) -> None:
+    """Make `import webview` fail so the GUI path exits instead of opening a
+    real window (dev venvs used for DMG builds have pywebview installed)."""
+    monkeypatch.setitem(sys.modules, "webview", None)
+
+
+def _stub_backend(monkeypatch) -> None:
+    """GUI path starts Flask before importing webview; do not bind a real port."""
+    import gui.app as gui_app
+
+    monkeypatch.setattr(gui_app, "start_backend_thread", lambda port=None: (8765, None))
+    monkeypatch.setattr(desktop, "_wait_for_backend", lambda port, timeout_sec=60.0: True)
+
+
 def test_cli_flag_dispatches_with_flag_stripped(monkeypatch):
     calls = _stub_cli_main(monkeypatch, result=7)
     monkeypatch.setattr(sys, "argv", ["RallyClip", "--cli", "--video", "match.mp4", "--write-csv"])
@@ -42,14 +63,9 @@ def test_cli_flag_without_args_still_dispatches_to_cli(monkeypatch):
     assert calls["force_cli"] is True
 
 
-def _block_webview(monkeypatch):
-    """Make `import webview` fail so the GUI path exits instead of opening a
-    real window (dev venvs used for DMG builds have pywebview installed)."""
-    monkeypatch.setitem(sys.modules, "webview", None)
-
-
 def test_cli_flag_only_recognized_as_argv1(monkeypatch):
     calls = _stub_cli_main(monkeypatch)
+    _stub_backend(monkeypatch)
     _block_webview(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["RallyClip", "--video", "x.mp4", "--cli"])
 
@@ -59,6 +75,7 @@ def test_cli_flag_only_recognized_as_argv1(monkeypatch):
 
 def test_no_args_takes_gui_path(monkeypatch):
     calls = _stub_cli_main(monkeypatch)
+    _stub_backend(monkeypatch)
     _block_webview(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["RallyClip"])
 
@@ -66,7 +83,34 @@ def test_no_args_takes_gui_path(monkeypatch):
     assert "argv" not in calls
 
 
+def test_gui_path_creates_window_then_starts(monkeypatch, capsys):
+    _stub_backend(monkeypatch)
+    created: dict = {}
+    started: list = []
+
+    fake = types.ModuleType("webview")
+    fake.settings = {}
+
+    def create_window(title, url, **kwargs):
+        created["title"] = title
+        created["url"] = url
+        created["kwargs"] = kwargs
+        return types.SimpleNamespace(uid="w1")
+
+    fake.create_window = create_window
+    fake.start = lambda: started.append(True)
+    monkeypatch.setitem(sys.modules, "webview", fake)
+    monkeypatch.setattr(sys, "argv", ["RallyClip"])
+
+    assert desktop.main() == 0
+    assert created["title"] == "RallyClip"
+    assert created["url"] == "http://127.0.0.1:8765/"
+    assert started == [True]
+    assert "RallyClip desktop shell ready" in capsys.readouterr().out
+
+
 def test_backend_only_skips_webview(monkeypatch):
+    _block_webview(monkeypatch)
     launched: dict = {}
 
     def fake_launch(*, open_browser: bool = True) -> int:
@@ -76,8 +120,27 @@ def test_backend_only_skips_webview(monkeypatch):
     import gui.app as gui_app
 
     monkeypatch.setattr(gui_app, "launch", fake_launch)
-    _block_webview(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["RallyClip", "--backend-only"])
 
     assert desktop.main() == 0
     assert launched["open_browser"] is False
+    assert sys.modules.get("webview") is None
+
+
+def test_gui_app_imports_without_webview():
+    """Fresh interpreter with webview blocked — catches a module-level import."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(ROOT / "src")
+    script = (
+        "import sys\n"
+        "sys.modules['webview'] = None\n"
+        "import gui.app\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -264,7 +264,9 @@ def test_release_workflow_uses_spec_and_signing_pipeline():
     assert "models/rallyclip_v0.3.1" not in workflow
     assert "python -m runtime.artifact fetch" in workflow
     assert "verify_artifact_dir" in workflow
-    assert '"$BIN" --backend-only' in workflow
+    assert '"$BIN" --backend-only' not in workflow
+    assert "RallyClip desktop shell ready" in workflow
+    assert "Probe packaged GUI boot" in workflow
     assert "timeout-minutes: 180" in workflow
     assert "Require Apple Silicon runner" in workflow
     assert "uname -m" in workflow

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -264,6 +264,7 @@ def test_release_workflow_uses_spec_and_signing_pipeline():
     assert "models/rallyclip_v0.3.1" not in workflow
     assert "python -m runtime.artifact fetch" in workflow
     assert "verify_artifact_dir" in workflow
+    assert '"$BIN" --backend-only' in workflow
     assert "timeout-minutes: 180" in workflow
     assert "Require Apple Silicon runner" in workflow
     assert "uname -m" in workflow

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -267,6 +267,7 @@ def test_release_workflow_uses_spec_and_signing_pipeline():
     assert '"$BIN" --backend-only' not in workflow
     assert "RallyClip desktop shell ready" in workflow
     assert "Probe packaged GUI boot" in workflow
+    assert "kill -0" in workflow
     assert "timeout-minutes: 180" in workflow
     assert "Require Apple Silicon runner" in workflow
     assert "uname -m" in workflow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Release `v0.5.0` failed at **Probe GUI backend boot**. The only log line was `RallyClip backend failed to start.`

The probe launched the full GUI binary. Importing pywebview/WKWebView on the GitHub-hosted Mac stalled **before** Flask started, so `/api/health` never answered within 30s. Headless CLI smoke on the same bundle had already passed.

`--backend-only` as the probe would miss a broken pywebview bundle (Greptile; agreed). Printing “ready” after `create_window()` is also insufficient: that call only allocates the Python Window object; native WKWebView starts in `webview.start()`.

**Fix:**
- GUI path starts Flask and waits for `/api/health` **before** importing webview (60s).
- `RallyClip desktop shell ready` prints from `window.events.loaded` (DOM ready in WKWebView).
- Release probe launches `"$BIN"` (no `--backend-only`), requires health **and** that ready line, `kill -0`s the process, then checks defaults for the pose ONNX name.
- `--backend-only` stays as a debug flag only.

After merge, move tag `v0.5.0` onto the new `main` and force-push the tag to re-run Release:

```bash
git checkout main && git pull
git tag -d v0.5.0
git tag -a v0.5.0 -m "RallyClip 0.5.0" origin/main
git push --force origin v0.5.0
```

## Test plan

- [x] Dispatch tests: Flask stub on GUI path; ready line only after fake `events.loaded`; `gui.app` import with webview blocked in a fresh interpreter
- [x] Default gate 302 passed
- [x] Greptile 5/5
- [x] CI green on `7272c78`
- [ ] Release workflow GUI probe on the moved `v0.5.0` tag

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-550709d8-6692-4c25-8fda-2ab81c845f28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-550709d8-6692-4c25-8fda-2ab81c845f28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

